### PR TITLE
Fix bug with read-only dynamically scoped $_

### DIFF
--- a/lib/Alien/Build/Plugin/Extract/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Extract/CommandLine.pm
@@ -285,6 +285,7 @@ sub _tar_can
   unless(%tars)
   {
     my $name = '';
+    local $_; # to avoid dynamically scoped read-only $_ from upper scopes
     while(<DATA>)
     {
       if(/^\[ (.*) \]$/)

--- a/t/alien_build_plugin_extract_commandline_tar_can.t
+++ b/t/alien_build_plugin_extract_commandline_tar_can.t
@@ -1,0 +1,21 @@
+use Test2::V0 -no_srand => 1;
+use Test::Alien::Build;
+use Alien::Build::Plugin::Extract::CommandLine;
+
+use Readonly;
+
+subtest 'tar can' => sub {
+  my $build = alienfile filename => 'corpus/blank/alienfile';
+  my $meta = $build->meta;
+
+  my $plugin = Alien::Build::Plugin::Extract::CommandLine->new;
+
+  Readonly::Scalar $_ => 'a';
+  $plugin->init($meta);
+
+  ok lives {
+    $plugin->_tar_can('.tar.gz');
+  }, 'can read from <DATA> with readonly $_' or note($@);
+};
+
+done_testing;


### PR DESCRIPTION
This bug was uncovered by this `map { }` over a constant list in `Dist::Zilla::Plugin::AlienBuild`: <https://github.com/plicease/Dist-Zilla-Plugin-AlienBuild/blob/v0.23/lib/Dist/Zilla/Plugin/AlienBuild.pm#L253>.