### PR TITLE
Add share/pkgconfig to PKG_CONFIG_PATH (Fixes #39)

### DIFF
--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -810,12 +810,14 @@ sub load_requires
     if(($mod->can('runtime_prop') && $mod->runtime_prop)
     || ($mod->isa('Alien::Base')  && $mod->install_type('share')))
     {
-      my $path = _path($mod->dist_dir)->child('lib/pkgconfig');
-      if(-d $path)
-      {
-        push @{ $self->{pkg_config_path} }, $path->stringify;
+      for my $dir (qw(lib share)) {
+          my $path = _path($mod->dist_dir)->child("$dir/pkgconfig");
+          if(-d $path)
+          {
+            push @{ $self->{pkg_config_path} }, $path->stringify;
+          }
       }
-      $path = _path($mod->dist_dir)->child('share/aclocal');
+      my $path = _path($mod->dist_dir)->child('share/aclocal');
       if(-d $path)
       {
         $path = "$path";

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -137,16 +137,19 @@ sub init
       if(_win)
       {
         my $real_prefix = Path::Tiny->new($build->install_prop->{prefix});
-        my $pkgconf_dir = Path::Tiny->new($ENV{DESTDIR})->child($prefix)->child('lib/pkgconfig');
+        my @pkgconf_dirs;
+        push @pkgconf_dirs, Path::Tiny->new($ENV{DESTDIR})->child($prefix)->child("$_/pkgconfig") for qw(lib share);
       
         # for any pkg-config style .pc files that are dropped, we need
         # to convert the MSYS /C/Foo style paths to C:/Foo
-        if(-d $pkgconf_dir)
-        {
-          foreach my $pc_file ($pkgconf_dir->children)
-          {
-            $pc_file->edit(sub {s/\Q$prefix\E/$real_prefix->stringify/eg;});
-          }
+        for my $pkgconf_dir (@pkgconf_dirs) {
+            if(-d $pkgconf_dir)
+            {
+              foreach my $pc_file ($pkgconf_dir->children)
+              {
+                $pc_file->edit(sub {s/\Q$prefix\E/$real_prefix->stringify/eg;});
+              }
+            }
         }
       }
       

--- a/lib/Alien/Build/Plugin/Core/Gather.pm
+++ b/lib/Alien/Build/Plugin/Core/Gather.pm
@@ -43,8 +43,11 @@ sub init
       local $ENV{PKG_CONFIG_PATH} = $ENV{PKG_CONFIG_PATH};
       unshift @PATH, Path::Tiny->new('bin')->absolute->stringify
         if -d 'bin';
-      unshift @PKG_CONFIG_PATH, Path::Tiny->new('lib/pkgconfig')->absolute->stringify
-        if -d 'lib/pkgconfig';
+
+      for my $dir (qw(share lib)) {
+          unshift @PKG_CONFIG_PATH, Path::Tiny->new("$dir/pkgconfig")->absolute->stringify
+            if -d "$dir/pkgconfig";
+      }
       
       $orig->($build) 
     }


### PR DESCRIPTION
pkg-config(1) now searches in `share/pkgconfig` along with `lib/pkgconfig`.

To verify:

```
git clone -b pkg-config-to-share --single-branch https://github.com/athreef/Alien-XInputSimulator
dzil authordeps --missing | cpanm -n
dzil listdeps   --missing | cpanm -n
dzil test
```

This one installs a `XInputSimulator.pc` to `$prefix/share/pkgconfig`. The unit tests fail with current Alien::Build, but succeed with the changes in this patch.
