### PR TITLE
Abstract fix

### DIFF
--- a/lib/Alien/Build/Plugin/Extract/ArchiveZip.pm
+++ b/lib/Alien/Build/Plugin/Extract/ArchiveZip.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Alien::Build::Plugin;
 
-# ABSTRACT: Plugin to extract a tarball using Archive::Tar
+# ABSTRACT: Plugin to extract a tarball using Archive::Zip
 # VERSION
 
 =head1 SYNOPSIS

--- a/lib/Alien/Build/Plugin/Fetch/CurlCommand.pm
+++ b/lib/Alien/Build/Plugin/Fetch/CurlCommand.pm
@@ -10,7 +10,7 @@ use Capture::Tiny qw( capture );
 use File::Temp qw( tempdir );
 use File::chdir;
 
-# ABSTRACT: Curl command line plugin for fetching files
+# ABSTRACT: Plugin for fetching files using curl
 # VERSION
 
 =head1 SYNOPSIS

--- a/lib/Alien/Build/Plugin/Fetch/HTTPTiny.pm
+++ b/lib/Alien/Build/Plugin/Fetch/HTTPTiny.pm
@@ -6,7 +6,7 @@ use Alien::Build::Plugin;
 use File::Basename ();
 use Carp ();
 
-# ABSTRACT: LWP plugin for fetching files
+# ABSTRACT: Plugin for fetching files using HTTP::Tiny
 # VERSION
 
 =head1 SYNOPSIS

--- a/lib/Alien/Build/Plugin/Fetch/LWP.pm
+++ b/lib/Alien/Build/Plugin/Fetch/LWP.pm
@@ -5,7 +5,7 @@ use warnings;
 use Alien::Build::Plugin;
 use Carp ();
 
-# ABSTRACT: LWP plugin for fetching files
+# ABSTRACT: Plugin for fetching files using LWP
 # VERSION
 
 =head1 SYNOPSIS

--- a/lib/Alien/Build/Plugin/Fetch/Local.pm
+++ b/lib/Alien/Build/Plugin/Fetch/Local.pm
@@ -6,7 +6,7 @@ use Alien::Build::Plugin;
 use File::chdir;
 use Path::Tiny ();
 
-# ABSTRACT: Local file plugin for fetching files
+# ABSTRACT: Plugin for fetching a local file
 # VERSION
 
 =head1 SYNOPSIS

--- a/lib/Alien/Build/Plugin/Fetch/LocalDir.pm
+++ b/lib/Alien/Build/Plugin/Fetch/LocalDir.pm
@@ -6,7 +6,7 @@ use Alien::Build::Plugin;
 use File::chdir;
 use Path::Tiny ();
 
-# ABSTRACT: Local directory plugin for fetching files
+# ABSTRACT: Plugin for fetching a local directory
 # VERSION
 
 =head1 SYNOPSIS

--- a/lib/Alien/Build/Plugin/Fetch/NetFTP.pm
+++ b/lib/Alien/Build/Plugin/Fetch/NetFTP.pm
@@ -7,7 +7,7 @@ use Carp ();
 use File::Temp ();
 use Path::Tiny qw( path );
 
-# ABSTRACT: Net::FTP plugin for fetching files
+# ABSTRACT: Plugin for fetching files using Net::FTP
 # VERSION
 
 =head1 SYNOPSIS

--- a/lib/Alien/Build/Plugin/Gather/IsolateDynamic.pm
+++ b/lib/Alien/Build/Plugin/Gather/IsolateDynamic.pm
@@ -7,7 +7,7 @@ use Path::Tiny ();
 use Alien::Build::Util qw( _destdir_prefix );
 use File::Copy ();
 
-# ABSTRACT: LWP plugin for fetching files
+# ABSTRACT: Plugin to gather dynamic libraries into a separate directory
 # VERSION
 
 =head1 SYNOPSIS

--- a/lib/Alien/Build/Plugin/Prefer/BadVersion.pm
+++ b/lib/Alien/Build/Plugin/Prefer/BadVersion.pm
@@ -5,7 +5,7 @@ use warnings;
 use Alien::Build::Plugin;
 use Carp ();
 
-# ABSTRACT: Filter out known bad versions
+# ABSTRACT: Plugin to filter out known bad versions
 # VERSION
 
 =head1 SYNOPSIS


### PR DESCRIPTION
I noticed some of the included plugins had abstracts that were repeated from other modules (eg. Gather::IsolateDynamic and Fetch::HTTPTiny had the abstract for Fetch::LWP).

This cosmetic patch fixes that, and also makes some small changes to the abstract of some other plugins, to make them a bit more predictable. But of course, you can feel free to cherry pick that commit out if you prefer.
