### PR TITLE
Remove trailing spaces

### DIFF
--- a/Changes.Alien-Base
+++ b/Changes.Alien-Base
@@ -44,8 +44,8 @@ After 0.043_01 Alien-Base was merged with Alien-Build
     reference
 
 0.032 2017-02-09 13:36:07 -0500
-  - Automatically add SSL modules as prereqs if we can tell with 
-    certainity that we will need to use HTTP::Tiny with SSL (plicease 
+  - Automatically add SSL modules as prereqs if we can tell with
+    certainity that we will need to use HTTP::Tiny with SSL (plicease
     gh#178)
   - Add environment override of repository settings (gh#180 nshp++)
 
@@ -174,7 +174,7 @@ After 0.043_01 Alien-Base was merged with Alien-Build
 
 0.019_01  Mon Jul  6, 2015
   - Improved documentation: added a FAQ at Alien::Base::FAQ
-  - Added helpers for source code builds see 
+  - Added helpers for source code builds see
     Alien::Base#alien_helper
     and
     Alien::Base::ModuleBuild::API#alien_helper
@@ -417,7 +417,7 @@ After 0.043_01 Alien-Base was merged with Alien-Build
 
 0.000_020  Jun 22, 2012
 	- Windows now passes the test suite (another cleanup error trapped)
-	- Begin overloading copy_if_modified for relocalizing dylibs on mac 
+	- Begin overloading copy_if_modified for relocalizing dylibs on mac
             (this is not working yet, this release is for windows testers)
 
 0.000_019  Jun 21, 2012
@@ -468,7 +468,7 @@ After 0.043_01 Alien-Base was merged with Alien-Build
 	- More bugfixes
 
 0.000_006  Apr 3, 2012
-	- Yet anther bugfix(?) release 
+	- Yet anther bugfix(?) release
 
 0.000_005  Apr 2, 2012
 	- Bugfix: A::B::PkgConfig _manual key shouldn't emit undef values

--- a/Changes.Test-Alien
+++ b/Changes.Test-Alien
@@ -25,7 +25,7 @@ After 0.15 Test-Alien was merged with Alien-Build
     by the Alien module.
 
 0.09      2017-01-13 07:13:38 -0500
-  - Test::Alien::Run#note and #diag can be chained like the other 
+  - Test::Alien::Run#note and #diag can be chained like the other
     methods
 
 0.08      2016-12-29 18:03:35 -0500

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Build external dependencies for use in CPAN
 
 # DESCRIPTION
 
-This module provides tools for building external (non-CPAN) dependencies 
-for CPAN.  It is mainly designed to be used at install time of a CPAN 
+This module provides tools for building external (non-CPAN) dependencies
+for CPAN.  It is mainly designed to be used at install time of a CPAN
 client, and work closely with [Alien::Base](https://metacpan.org/pod/Alien::Base) which is used at runtime.
 
 This is the detailed documentation for the [Alien::Build](https://metacpan.org/pod/Alien::Build) class.
@@ -68,8 +68,8 @@ properties may need to be serialized into something primitive like JSON
 that does not support: regular expressions, code references of blessed
 objects.
 
-If you are writing a plugin ([Alien::Build::Plugin](https://metacpan.org/pod/Alien::Build::Plugin)) you should use a 
-prefix like "plugin\__name_" (where _name_ is the name of your plugin) 
+If you are writing a plugin ([Alien::Build::Plugin](https://metacpan.org/pod/Alien::Build::Plugin)) you should use a
+prefix like "plugin\__name_" (where _name_ is the name of your plugin)
 so that it does not interfere with other plugin or future versions of
 [Alien::Build](https://metacpan.org/pod/Alien::Build).  For example, if you were writing
 `Alien::Build::Plugin::Fetch::NewProtocol`, please use the prefix
@@ -78,9 +78,9 @@ so that it does not interfere with other plugin or future versions of
     sub init
     {
       my($self, $meta) = @_;
-      
+
       $meta->prop( plugin_fetch_newprotocol_foo => 'some value' );
-      
+
       $meta->register_hook(
         some_hook => sub {
           my($build) = @_;
@@ -93,9 +93,9 @@ so that it does not interfere with other plugin or future versions of
 If you are writing a [alienfile](https://metacpan.org/pod/alienfile) recipe please use the prefix `my_`:
 
     use alienfile;
-    
+
     meta_prop->{my_foo} = 'some value';
-    
+
     probe sub {
       my($build) = @_;
       $build->install_prop->{my_bar} = 'some other value';
@@ -308,7 +308,7 @@ relevant once the install process is complete.
     The name DLL or shared object "name" to use when searching for dynamic
     libraries at runtime.  This is passed into [FFI::CheckLib](https://metacpan.org/pod/FFI::CheckLib), so if
     your library is something like `libarchive.so` or `archive.dll` you
-    would set this to `archive`.  This may be a string or an array of 
+    would set this to `archive`.  This may be a string or an array of
     strings.
 
 - install\_type
@@ -393,7 +393,7 @@ This is just a shortcut for:
 
     my $root = $build->install_prop->{root};
 
-Except that it will be created if it does not already exist.  
+Except that it will be created if it does not already exist.
 
 ## install\_type
 
@@ -678,22 +678,22 @@ Apply the given plugin with the given arguments.
 
 # SUPPORT
 
-The intent of the `Alien-Build` team is to support as best as possible 
-all Perls from 5.8.1 to the latest production version.  So long as they 
+The intent of the `Alien-Build` team is to support as best as possible
+all Perls from 5.8.1 to the latest production version.  So long as they
 are also supported by the Perl toolchain.
 
-Please feel encouraged to report issues that you encounter to the 
+Please feel encouraged to report issues that you encounter to the
 project GitHub Issue tracker:
 
 - [https://github.com/Perl5-Alien/Alien-Build/issues](https://github.com/Perl5-Alien/Alien-Build/issues)
 
-Better if you can fix the issue yourself, please feel encouraged to open 
+Better if you can fix the issue yourself, please feel encouraged to open
 pull-request on the project GitHub:
 
 - [https://github.com/Perl5-Alien/Alien-Build/pulls](https://github.com/Perl5-Alien/Alien-Build/pulls)
 
-If you are confounded and have questions, join us on the `#native` 
-channel on irc.perl.org.  The `Alien-Build` developers frequent this 
+If you are confounded and have questions, join us on the `#native`
+channel on irc.perl.org.  The `Alien-Build` developers frequent this
 channel and can probably help point you in the right direction.  If you
 don't have an IRC client handy, you can use this web interface:
 

--- a/corpus/cmake-libpalindrome/LICENSE
+++ b/corpus/cmake-libpalindrome/LICENSE
@@ -292,21 +292,21 @@ Definitions:
 
   - "Package" refers to the collection of files distributed by the Copyright
     Holder, and derivatives of that collection of files created through
-    textual modification. 
+    textual modification.
   - "Standard Version" refers to such a Package if it has not been modified,
     or has been modified in accordance with the wishes of the Copyright
-    Holder. 
+    Holder.
   - "Copyright Holder" is whoever is named in the copyright or copyrights for
-    the package. 
+    the package.
   - "You" is you, if you're thinking about copying or distributing this Package.
   - "Reasonable copying fee" is whatever you can justify on the basis of media
     cost, duplication charges, time of people involved, and so on. (You will
     not be required to justify it to the Copyright Holder, but only to the
-    computing community at large as a market that must bear the fee.) 
+    computing community at large as a market that must bear the fee.)
   - "Freely Available" means that no fee is charged for the item itself, though
     there may be fees involved in handling the item. It also means that
     recipients of the item may redistribute it under the same conditions they
-    received it. 
+    received it.
 
 1. You may make and give away verbatim copies of the source form of the
 Standard Version of this Package without restriction, provided that you

--- a/corpus/lib/Alien/Build/Plugin/Download/Foo.pm
+++ b/corpus/lib/Alien/Build/Plugin/Download/Foo.pm
@@ -7,13 +7,13 @@ use Alien::Build::Plugin;
 sub init
 {
   my($self,$meta) = @_;
-  
+
   require Alien::Build::Plugin::Download::Negotiate;
   require Alien::Build::Plugin::Extract::ArchiveTar;
-  
+
   Alien::Build::Plugin::Download::Negotiate->new(url => 'corpus/dist/foo-1.00.tar')->init($meta);
   Alien::Build::Plugin::Extract::ArchiveTar->new->init($meta);
-  
+
   $meta->register_hook(probe => sub { 'share' });
 }
 

--- a/corpus/lib/Alien/Build/Plugin/Fetch/Corpus.pm
+++ b/corpus/lib/Alien/Build/Plugin/Fetch/Corpus.pm
@@ -20,7 +20,7 @@ has regex => qr/\.tar\.gz$/;
 sub init
 {
   my($self, $meta) = @_;
-  
+
   my $list = {
     type => 'list',
     list => [
@@ -33,13 +33,13 @@ sub init
       } ((map { $_->basename } grep { -f $_ } _path('corpus/dist')->children), map { sprintf "foo-0.%02d.tar.gz", $_ } 0..99),
     ],
   };
-  
+
   $meta->register_hook(
     fetch => sub {
       my(undef, $url) = @_;
-      
+
       $url ||= $self->url;
-      
+
       if($url =~ qr!^http://test1\.test/foo/bar/baz/?$!)
       {
         if($self->return_listing_as eq 'list')
@@ -89,21 +89,21 @@ sub init
       }
     },
   );
-  
+
   $meta->register_hook(
     decode => sub {
       return $list;
     }
   );
-  
+
   $meta->register_hook(
     prefer => sub {
       my(undef, $res) = @_;
-      
+
       my @list = sort { $b->{filename} cmp $a->{filename} }
                  grep { $_->{filename} =~ $self->regex }
                  @{ $res->{list} };
-      
+
       return {
         type => 'list',
         list => \@list,

--- a/corpus/lib/Alien/Build/Plugin/RogerRamjet.pm
+++ b/corpus/lib/Alien/Build/Plugin/RogerRamjet.pm
@@ -11,12 +11,12 @@ has 'baz'  => undef;
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->prop->{ramjet} = 'roger';
   $meta->prop->{foo}    = $self->foo;
   $meta->prop->{bar}    = $self->bar;
   $meta->prop->{baz}    = $self->baz;
-  
+
 }
 
 1;

--- a/example/README
+++ b/example/README
@@ -5,12 +5,12 @@ the L<af> command if you have L<App::af> installed.  For example:
 
  % af install --prefix=/tmp/foo xz.alienfile
 
-If you want to force a C<share> install you can use the C<--type> 
+If you want to force a C<share> install you can use the C<--type>
 option:
 
  % af install --type=share --prefix=/tmp/foo xz.alienfile
 
-For more details on what you can do with the L<af> command, please see 
+For more details on what you can do with the L<af> command, please see
 its documentation.
 
 =cut

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -32,7 +32,7 @@ Then a C<MyLibrary::XS> can use C<Alien::MyLibrary> in its C<Makefile.PL>:
  use ExtUtils::MakeMaker;
  use Alien::Base::Wrapper qw( Alien::MyLibrary !export );
  use Config;
- 
+
  WriteMakefile(
    ...
    Alien::Base::Wrapper->mm_args,
@@ -44,13 +44,13 @@ Or if you prefer L<Module::Build>, in its C<Build.PL>:
  use Alien::MyLibrary;
  use Module::Build 0.28; # need at least 0.28
  use Alien::Base::Wrapper qw( Alien::MyLibrary !export );
- 
+
  my $builder = Module::Build->new(
    ...
    Alien::Base::Wrapper->mb_args,
    ...
  );
- 
+
  $builder->create_build_script;
 
 Or if you are using L<ExtUtils::Depends>:
@@ -68,27 +68,27 @@ and L<alienfile>, then in your C<MyLibrary::XS> module, you may need something l
 this in your main C<.pm> file IF your library uses dynamic libraries:
 
  package MyLibrary::XS;
- 
+
  use Alien::MyLibrary; # may only be needed if you are using Alien::Base::ModuleBuild
- 
+
  ...
 
 Or you can use it from an FFI module:
 
  package MyLibrary::FFI;
- 
+
  use Alien::MyLibrary;
  use FFI::Platypus;
- 
+
  my $ffi = FFI::Platypus->new;
  $ffi->lib(Alien::MyLibrary->dynamic_libs);
- 
+
  $ffi->attach( 'my_library_function' => [] => 'void' );
 
 You can even use it with L<Inline> (C and C++ languages are supported):
 
  package MyLibrary::Inline;
- 
+
  use Alien::MyLibrary;
  # Inline 0.56 or better is required
  use Inline 0.56 with => 'Alien::MyLibrary';
@@ -142,7 +142,7 @@ sub import {
   require DynaLoader;
 
   # Sanity check in order to ensure that dist_dir can be found.
-  # This will throw an exception otherwise.  
+  # This will throw an exception otherwise.
   $class->dist_dir;
 
   # get a reference to %Alien::MyLibrary::AlienLoaded
@@ -200,10 +200,10 @@ C<install_type> is C<share>).
 sub _dist_dir ($)
 {
   my($dist_name) = @_;
-  
+
   my @pm = split /-/, $dist_name;
   $pm[-1] .= ".pm";
-  
+
   foreach my $inc (@INC)
   {
     my $pm = Path::Tiny->new($inc, @pm);
@@ -226,8 +226,8 @@ sub dist_dir {
   my $dist = blessed $class || $class;
   $dist =~ s/::/-/g;
 
-  my $dist_dir = 
-    $class->config('finished_installing') 
+  my $dist_dir =
+    $class->config('finished_installing')
       ? _dist_dir $dist
       : $class->config('working_directory');
 
@@ -251,7 +251,7 @@ sub new { return bless {}, $_[0] }
 sub _flags
 {
   my($class, $key) = @_;
-  
+
   my $config = $class->runtime_prop;
   my $flags = $config->{$key};
 
@@ -259,16 +259,16 @@ sub _flags
   $prefix =~ s{\\}{/}g if $^O =~ /^(MSWin32|msys)$/;
   my $distdir = $config->{distdir};
   $distdir =~ s{\\}{/}g if $^O =~ /^(MSWin32|msys)$/;
-  
+
   if($prefix ne $distdir)
   {
-    $flags = join ' ', map { 
+    $flags = join ' ', map {
       s/^(-I|-L|-LIBPATH:)?\Q$prefix\E/$1$distdir/;
       s/(\s)/\\$1/g;
       $_;
     } $class->split_flags($flags);
   }
-  
+
   $flags;
 }
 
@@ -423,7 +423,7 @@ sub _pkgconfig_keyword {
   my @pc = $self->_pkgconfig(@_);
   my @strings =
     grep defined,
-    map { $_->keyword($keyword, 
+    map { $_->keyword($keyword,
       #{ pcfiledir => $dist_dir }
     ) }
     @pc;
@@ -456,14 +456,14 @@ sub _pkgconfig {
     $all{$pkg->{package}} = $pkg;
   };
   File::Find::find( $wanted, $self->dist_dir );
-    
+
   croak "No Alien::Base::PkgConfig objects are stored!"
     unless keys %all;
-  
+
   # Run through all pkgconfig objects and ensure that their modules are loaded:
   for my $pkg_obj (values %all) {
     my $perl_module_name = blessed $pkg_obj;
-    eval "require $perl_module_name"; 
+    eval "require $perl_module_name";
   }
 
   return @all{@_} if @_;
@@ -482,7 +482,7 @@ sub _pkgconfig {
  my $value = Alien::MyLibrary->config($key);
 
 Returns the configuration data as determined during the install
-of L<Alien::MyLibrary>.  For the appropriate config keys, see 
+of L<Alien::MyLibrary>.  For the appropriate config keys, see
 L<Alien::Base::ModuleBuild::API#CONFIG-DATA>.
 
 This is not typically used by L<Alien::Base> and L<alienfile>,
@@ -547,9 +547,9 @@ alien software.
 
 sub dynamic_libs {
   my ($class) = @_;
-  
+
   require FFI::CheckLib;
-  
+
   if($class->install_type('system')) {
 
     if(my $prop = $class->runtime_prop)
@@ -566,14 +566,14 @@ sub dynamic_libs {
       # strip trailing version numbers
       $name =~ s/-[0-9\.]+$//;
     }
-    
+
     return FFI::CheckLib::find_lib(lib => $name);
-  
+
   } else {
-  
+
     my $dir = $class->dist_dir;
     my $dynamic = Path::Tiny->new($class->dist_dir, 'dynamic');
-    
+
     if(-d $dynamic)
     {
       return FFI::CheckLib::find_lib(
@@ -605,7 +605,7 @@ get installed into non-standard locations.
 Example usage:
 
  use Env qw( @PATH );
- 
+
  unshft @PATH, Alien::MyLibrary->bin_dir;
 
 =cut
@@ -640,18 +640,18 @@ to override the method to create your own helpers.
 For use with commands specified in and L<alienfile> or in your C<Build.Pl>
 when used with L<Alien::Base::ModuleBuild>.
 
-Helpers allow users of your Alien module to use platform or environment 
+Helpers allow users of your Alien module to use platform or environment
 determined logic to compute command names or arguments in your installer
 logic.  Helpers allow you to do this without making your Alien module a
 requirement when a build from source code is not necessary.
 
-As a concrete example, consider L<Alien::gmake>, which provides the 
+As a concrete example, consider L<Alien::gmake>, which provides the
 helper C<gmake>:
 
  package Alien::gmake;
- 
+
  ...
- 
+
  sub alien_helper {
    my($class) = @_;
    return {
@@ -664,30 +664,30 @@ helper C<gmake>:
    },
  }
 
-Now consider L<Alien::nasm>.  C<nasm> requires GNU Make to build from 
-source code, but if the system C<nasm> package is installed we don't 
+Now consider L<Alien::nasm>.  C<nasm> requires GNU Make to build from
+source code, but if the system C<nasm> package is installed we don't
 need it.  From the L<alienfile> of C<Alien::nasm>:
 
  use alienfile;
- 
+
  plugin 'Probe::CommandLine' => (
    command => 'nasm',
    args    => ['-v'],
    match   => qr/NASM version/,
  );
- 
+
  share {
    ...
    plugin 'Extract' => 'tar.gz';
    plugin 'Build::MSYS';
-   
+
    build [
      'sh configure --prefix=%{alien.install.prefix}',
      '%{gmake}',
      '%{gmake} install',
    ];
  };
- 
+
  ...
 
 =cut
@@ -703,7 +703,7 @@ sub alien_helper {
 List of header files to automatically include in inline C and C++
 code when using L<Inline::C> or L<Inline::CPP>.  This is provided
 as a public interface primarily so that it can be overridden at run
-time.  This can also be specified in your C<Build.PL> with 
+time.  This can also be specified in your C<Build.PL> with
 L<Alien::Base::ModuleBuild> using the C<alien_inline_auto_include>
 property.
 
@@ -722,11 +722,11 @@ sub Inline {
     CCFLAGSEX    => $class->cflags,
     LIBS         => $class->libs,
   };
-  
+
   if (@{ $class->inline_auto_include } > 0) {
     $config->{AUTO_INCLUDE} = join "\n", map { "#include \"$_\"" } @{ $class->inline_auto_include };
   }
-  
+
   $config;
 }
 
@@ -746,10 +746,10 @@ then this will return undef.
   sub runtime_prop
   {
     my($class) = @_;
-  
+
     return $alien_build_config_cache{$class} if
       exists $alien_build_config_cache{$class};
-  
+
     $alien_build_config_cache{$class} ||= do {
       my $dist = ref $class ? ref $class : $class;
       $dist =~ s/::/-/g;
@@ -777,7 +777,7 @@ First check the L<Alien::Build::Manual::FAQ> for questions that have already bee
 
 IRC: #native on irc.perl.org
 
-L<(click for instant chatroom login)|http://chat.mibbit.com/#native@irc.perl.org> 
+L<(click for instant chatroom login)|http://chat.mibbit.com/#native@irc.perl.org>
 
 If you find a bug, please report it on the projects issue tracker on GitHub:
 
@@ -797,7 +797,7 @@ in GitHub.
 
 =back
 
-If you have implemented a new feature or fixed a bug, please open a pull 
+If you have implemented a new feature or fixed a bug, please open a pull
 request.
 
 =over 4
@@ -808,9 +808,9 @@ request.
 
 =head1 SEE ALSO
 
-=over 
+=over
 
-=item * 
+=item *
 
 L<Alien::Build>
 

--- a/lib/Alien/Base/PkgConfig.pm
+++ b/lib/Alien/Base/PkgConfig.pm
@@ -92,7 +92,7 @@ sub make_abstract {
   my ($var, $value) = @_;
 
   $value = defined $value ? $value : $self->{vars}{$var};
-    
+
   # convert other vars
   foreach my $key (keys %{ $self->{vars} }) {
     next if $key eq $var; # don't overwrite the current var
@@ -113,7 +113,7 @@ sub _interpolate_vars {
   $override ||= {};
 
   foreach my $key (keys %$override) {
-    carp "Overriden pkg-config variable $key, contains no data" 
+    carp "Overriden pkg-config variable $key, contains no data"
       unless $override->{$key};
   }
 
@@ -126,7 +126,7 @@ sub _interpolate_vars {
 sub keyword {
   my $self = shift;
   my ($keyword, $override) = @_;
-  
+
   {
     no warnings 'uninitialized';
     croak "overrides passed to 'keyword' must be a hashref"
@@ -141,7 +141,7 @@ my $pkg_config_command;
 sub pkg_config_command {
   unless (defined $pkg_config_command) {
     capture_stderr {
-    
+
       # For now we prefer PkgConfig.pm over pkg-config on
       # Solaris 64 bit Perls.  We may need to do this on
       # other platforms, in which case this logic should
@@ -156,7 +156,7 @@ sub pkg_config_command {
       }
     }
   }
-  
+
   $pkg_config_command;
 }
 

--- a/lib/Alien/Base/Wrapper.pm
+++ b/lib/Alien/Base/Wrapper.pm
@@ -7,7 +7,7 @@ use Config;
 use Text::ParseWords qw( shellwords );
 
 # NOTE: Although this module is now distributed with Alien-Build,
-# it should have NO non-perl-core dependencies for all Perls 
+# it should have NO non-perl-core dependencies for all Perls
 # 5.8.1-5.26.0 (as of this writing, and any Perl more recent).
 # You should be able to extract this module from the rest of
 # Alien-Build and use it by itself.
@@ -29,7 +29,7 @@ From Makefile.PL (non-dynamic):
 
  use ExtUtils::MakeMaker;
  use Alien::Base::Wrapper qw( Alien::Foo Alien::Bar !export );
- 
+
  WriteMakefile(
    'NAME'              => 'Foo::XS',
    'VERSION_FROM'      => 'lib/Foo/XS.pm',
@@ -45,10 +45,10 @@ From Makefile.PL (dynamic):
 
  use Devel::CheckLib qw( check_lib );
  use ExtUtils::MakeMaker 6.52;
- 
+
  my @mm_args;
  my @libs;
- 
+
  if(check_lib( lib => [ 'foo' ] )
  {
    push @mm_args, LIBS => [ '-lfoo' ];
@@ -73,7 +73,7 @@ From Makefile.PL (dynamic):
    },
    @mm_args,
  );
- 
+
 =head1 DESCRIPTION
 
 This module acts as a wrapper around one or more L<Alien> modules.  It is designed to work
@@ -229,18 +229,18 @@ sub import
       $cflags = $alien->cflags;
       $libs   = $alien->libs;
     }
-    
+
     push @cflags_I,     grep  /^-I/, shellwords $cflags;
     push @cflags_other, grep !/^-I/, shellwords $cflags;
-    
+
     push @ldflags_L,     grep  /^-L/,    shellwords $libs;
     push @ldflags_l,     grep  /^-l/,    shellwords $libs;
     push @ldflags_other, grep !/^-[Ll]/, shellwords $libs;
   }
-  
+
   my @cflags_define = grep  /^-D/, @cflags_other;
   my @cflags_other2 = grep !/^-D/, @cflags_other;
-  
+
   @mm = ();
 
   push @mm, INC       => _join @cflags_I                             if @cflags_I;
@@ -253,10 +253,10 @@ sub import
   push @mm, LDFLAGS   => _join(@ldflags) . " $Config{ldflags}"       if @ldflags;
 
   @mb = ();
-  
+
   push @mb, extra_compiler_flags => _join(@cflags_I, @cflags_other);
   push @mb, extra_linker_flags   => _join(@ldflags_l);
-  
+
   if(@ldflags)
   {
     push @mb, config => {
@@ -264,14 +264,14 @@ sub import
       ldflags   => _join(@ldflags) . " $Config{ldflags}",
     },
   }
-  
+
   if($export)
   {
     my $caller = caller;
     no strict 'refs';
     *{"${caller}::cc"} = \&cc;
     *{"${caller}::ld"} = \&ld;
-  }  
+  }
 }
 
 1;

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -28,8 +28,8 @@ use Config ();
 
 =head1 DESCRIPTION
 
-This module provides tools for building external (non-CPAN) dependencies 
-for CPAN.  It is mainly designed to be used at install time of a CPAN 
+This module provides tools for building external (non-CPAN) dependencies
+for CPAN.  It is mainly designed to be used at install time of a CPAN
 client, and work closely with L<Alien::Base> which is used at runtime.
 
 This is the detailed documentation for the L<Alien::Build> class.
@@ -96,19 +96,19 @@ sub new
     pkg_config_path => [],
     aclocal_path => [],
   }, $class;
-  
+
   $self->meta->filename(
     $args{filename} || do {
       my(undef, $filename) = caller;
       _path($filename)->absolute->stringify;
     }
   );
-  
+
   if($args{meta_prop})
   {
     $self->meta->prop->{$_} = $args{meta_prop}->{$_} for keys %{ $args{meta_prop} };
   }
-  
+
   $self;
 }
 
@@ -120,8 +120,8 @@ properties may need to be serialized into something primitive like JSON
 that does not support: regular expressions, code references of blessed
 objects.
 
-If you are writing a plugin (L<Alien::Build::Plugin>) you should use a 
-prefix like "plugin_I<name>" (where I<name> is the name of your plugin) 
+If you are writing a plugin (L<Alien::Build::Plugin>) you should use a
+prefix like "plugin_I<name>" (where I<name> is the name of your plugin)
 so that it does not interfere with other plugin or future versions of
 L<Alien::Build>.  For example, if you were writing
 C<Alien::Build::Plugin::Fetch::NewProtocol>, please use the prefix
@@ -130,9 +130,9 @@ C<plugin_fetch_newprotocol>:
  sub init
  {
    my($self, $meta) = @_;
-   
+
    $meta->prop( plugin_fetch_newprotocol_foo => 'some value' );
-   
+
    $meta->register_hook(
      some_hook => sub {
        my($build) = @_;
@@ -145,9 +145,9 @@ C<plugin_fetch_newprotocol>:
 If you are writing a L<alienfile> recipe please use the prefix C<my_>:
 
  use alienfile;
- 
+
  meta_prop->{my_foo} = 'some value';
- 
+
  probe sub {
    my($build) = @_;
    $build->install_prop->{my_bar} = 'some other value';
@@ -407,7 +407,7 @@ Linux and C<gmake> on FreeBSD.
 The name DLL or shared object "name" to use when searching for dynamic
 libraries at runtime.  This is passed into L<FFI::CheckLib>, so if
 your library is something like C<libarchive.so> or C<archive.dll> you
-would set this to C<archive>.  This may be a string or an array of 
+would set this to C<archive>.  This may be a string or an array of
 strings.
 
 =item install_type
@@ -553,7 +553,7 @@ sub load
 
   my $class = "Alien::Build::Auto::$name@{[ $count++ ]}";
 
-  { no strict 'refs';  
+  { no strict 'refs';
   @{ "${class}::ISA" } = ('Alien::Build');
   *{ "${class}::Alienfile::meta" } = sub {
     $class =~ s{::Alienfile$}{};
@@ -564,7 +564,7 @@ sub load
   push @preload, @Alien::Build::rc::PRELOAD;
   push @preload, split ';', $ENV{ALIEN_BUILD_PRELOAD}
     if defined $ENV{ALIEN_BUILD_PRELOAD};
-  
+
   my @postload = qw( Core::Legacy Core::Gather Core::Tail );
   push @postload, @Alien::Build::rc::POSTLOAD;
   push @postload, split ';', $ENV{ALIEN_BUILD_POSTLOAD}
@@ -574,7 +574,7 @@ sub load
     filename => $file->absolute->stringify,
     @args,
   );
-  
+
   require alienfile;
 
   foreach my $preload (@preload)
@@ -655,7 +655,7 @@ This is just a shortcut for:
 
  my $root = $build->install_prop->{root};
 
-Except that it will be created if it does not already exist.  
+Except that it will be created if it does not already exist.
 
 =cut
 
@@ -695,10 +695,10 @@ and similar modules.  It is not intended for use from plugins or from an L<alien
 sub set_prefix
 {
   my($self, $prefix) = @_;
-  
+
   if($self->meta_prop->{destdir})
   {
-    $self->runtime_prop->{prefix} = 
+    $self->runtime_prop->{prefix} =
     $self->install_prop->{prefix} = $prefix;
   }
   else
@@ -797,7 +797,7 @@ sub load_requires
       $pm;
     };
     die "Required $mod $ver, have @{[ $mod->VERSION || 0 ]}" if $ver && ! $mod->VERSION($ver);
-    
+
     # allow for requires on Alien::Build or Alien::Base
     next if $mod eq 'Alien::Build';
     next if $mod eq 'Alien::Base';
@@ -829,14 +829,14 @@ sub load_requires
         push @{ $self->{aclocal_path} }, $path;
       }
     }
-    
+
     # sufficiently new Autotools have a aclocal_dir which will
     # give us the directories we need.
     if($mod eq 'Alien::Autotools' && $mod->can('aclocal_dir'))
     {
       push @{ $self->{aclocal_path} }, $mod->aclocal_dir;
     }
-    
+
     if($mod->can('alien_helper'))
     {
       my $helpers = $mod->alien_helper;
@@ -854,13 +854,13 @@ sub load_requires
 sub _call_hook
 {
   my $self = shift;
-  
+
   local $ENV{PATH} = $ENV{PATH};
   unshift @PATH, @{ $self->{bin_dir} };
-  
+
   local $ENV{PKG_CONFIG_PATH} = $ENV{PKG_CONFIG_PATH};
   unshift @PKG_CONFIG_PATH, @{ $self->{pkg_config_path} };
-  
+
   local $ENV{ACLOCAL_PATH} = $ENV{ACLOCAL_PATH};
   # autoconf uses MSYS paths, even for the ACLOCAL_PATH environment variable, so we can't use Env for this.
   {
@@ -869,14 +869,14 @@ sub _call_hook
     unshift @path, @{ $self->{aclocal_path} };
     $ENV{ACLOCAL_PATH} = join ':', @path;
   }
-  
+
   my $config = ref($_[0]) eq 'HASH' ? shift : {};
   my($name, @args) = @_;
-  
+
   local $self->{hook_prop} = {
     name => $name,
   };
-  
+
   $self->meta->call_hook( $config, $name => $self, @args );
 }
 
@@ -902,13 +902,13 @@ sub probe
   my($self) = @_;
   local $CWD = $self->root;
   my $dir;
-  
+
   my $env = $self->_call_hook('override');
   my $type;
   my $error;
-  
+
   $env = '' if $env eq 'default';
-  
+
   if($env eq 'share')
   {
     $type = 'share';
@@ -934,7 +934,7 @@ sub probe
     $error = $@;
     $type = 'share' unless defined $type;
   }
-  
+
   if($error)
   {
     if($env eq 'system')
@@ -946,19 +946,19 @@ sub probe
     $self->log("Do not file a bug unless you expected a system install to succeed.");
     $type = 'share';
   }
-  
+
   if($env && $env ne $type)
   {
     die "requested $env install not available";
   }
-  
+
   if($type !~ /^(system|share)$/)
   {
     Carp::croak "probe hook returned something other than system or share: $type";
   }
-  
+
   $self->runtime_prop->{install_type} = $type;
-  
+
   $type;
 }
 
@@ -975,16 +975,16 @@ Under a C<system> install this does not do anything.
 sub download
 {
   my($self) = @_;
-  
+
   return $self unless $self->install_type eq 'share';
   return $self if $self->install_prop->{complete}->{download};
-  
+
   if($self->meta->has_hook('download'))
   {
     my $tmp;
     local $CWD;
     my $valid = 0;
-    
+
     $self->_call_hook(
       {
         before => sub {
@@ -993,9 +993,9 @@ sub download
         },
         verify => sub {
           my @list = grep { $_->basename !~ /^\./, } _path('.')->children;
-    
+
           my $count = scalar @list;
-    
+
           if($count == 0)
           {
             die "no files downloaded";
@@ -1021,7 +1021,7 @@ sub download
             $self->install_prop->{complete}->{download} = 1;
             $self->install_prop->{download} = _path('.')->absolute->stringify;
             $valid = 1;
-          }   
+          }
         },
         after  => sub {
           $CWD = $self->root;
@@ -1029,7 +1029,7 @@ sub download
       },
       'download',
     );
-    
+
     return $self if $valid;
   }
   else
@@ -1037,9 +1037,9 @@ sub download
     # This will call the default download hook
     # defined in Core::Download since the recipe
     # does not provide a download hook
-    return $self->_call_hook('download');  
+    return $self->_call_hook('download');
   }
-  
+
   die "download failed";
 }
 
@@ -1103,9 +1103,9 @@ to L<Alien::Build>, and for normal usage is not needed from a plugin or L<alienf
 sub extract
 {
   my($self, $archive) = @_;
-  
+
   $archive ||= $self->install_prop->{download};
-  
+
   unless(defined $archive)
   {
     die "tried to call extract before download";
@@ -1119,32 +1119,32 @@ sub extract
     my $extract = $self->install_prop->{extract};
     return $extract if defined $extract && -d $extract;
   }
-  
+
   my $tmp;
   local $CWD;
   my $ret;
 
   $self->_call_hook({
-  
+
     before => sub {
-      # called build instead of extract, because this 
+      # called build instead of extract, because this
       # will be used for the build step, and technically
       # extract is a substage of build anyway.
       $tmp = Alien::Build::TempDir->new($self, $nick_name);
       $CWD = "$tmp";
     },
     verify => sub {
-    
+
       my $path = '.';
       if($self->meta_prop->{out_of_source} && $self->install_prop->{extract})
       {
         $path = $self->install_prop->{extract};
       }
-    
+
       my @list = grep { $_->basename !~ /^\./ && $_->basename ne 'pax_global_header' } _path($path)->children;
-      
+
       my $count = scalar @list;
-      
+
       if($count == 0)
       {
         die "no files extracted";
@@ -1157,14 +1157,14 @@ sub extract
       {
         $ret = "$tmp";
       }
-    
+
     },
     after => sub {
       $CWD = $self->root;
     },
-  
+
   }, 'extract', $archive);
-  
+
   $self->install_prop->{extract} ||= $ret;
   $ret ? $ret : ();
 }
@@ -1199,12 +1199,12 @@ sub build
   # save the evironment, in case some plugins decide
   # to alter it.  Or us!  See just a few lines below.
   local %ENV = %ENV;
-  
+
   my $stage = _path($self->install_prop->{stage});
   $stage->mkpath;
-  
+
   my $tmp;
-  
+
   if($self->install_type eq 'share')
   {
     foreach my $suffix ('', '_ffi')
@@ -1246,12 +1246,12 @@ sub build
       $self->_call_hook("gather@{[ $suffix || '_share' ]}");
     }
   }
-  
+
   elsif($self->install_type eq 'system')
   {
     local $CWD = $self->root;
     my $dir;
-  
+
     $self->_call_hook(
       {
         before => sub {
@@ -1264,11 +1264,11 @@ sub build
       },
       'gather_system',
     );
-  
+
     $self->install_prop->{finished} = 1;
-    $self->install_prop->{complete}->{gather_system} = 1;  
+    $self->install_prop->{complete}->{gather_system} = 1;
   }
-  
+
   $self;
 }
 
@@ -1322,15 +1322,15 @@ the Perl C<system> command.
 sub system
 {
   my($self, $command, @args) = @_;
-  
+
   my $prop = $self->_command_prop;
-  
-  ($command, @args) = map { 
+
+  ($command, @args) = map {
     $self->meta->interpolator->interpolate($_, $prop)
   } ($command, @args);
 
   $self->log("+ $command @args");
-  
+
   scalar @args
     ? system $command, @args
     : system $command;
@@ -1656,9 +1656,9 @@ sub call_hook
   my %args = ref $_[0] ? %{ shift() } : ();
   my($name, @args) = @_;
   my $error;
-  
+
   my @hooks = @{ $self->{hook}->{$name} || []};
-  
+
   if(@hooks == 0)
   {
     if(defined $self->{default_hook}->{$name})
@@ -1670,7 +1670,7 @@ sub call_hook
       Carp::croak "No hooks registered for $name";
     }
   }
-  
+
   my $value;
 
   foreach my $hook (@hooks)
@@ -1709,9 +1709,9 @@ sub call_hook
       return $value;
     }
   }
-  
+
   die $error if $error && ! $args{all};
-  
+
   $value;
 }
 
@@ -1731,7 +1731,7 @@ sub apply_plugin
   my $class;
   my $pm;
   my $found;
-  
+
   if($name =~ /^=(.*)$/)
   {
     $class = $1;
@@ -1739,7 +1739,7 @@ sub apply_plugin
     $pm    =~ s!::!/!g;
     $found = 1;
   }
-  
+
   if($name !~ /::/ && !$found)
   {
     foreach my $inc (@INC)
@@ -1756,14 +1756,14 @@ sub apply_plugin
       }
     }
   }
-  
+
   unless($found)
   {
     $class = "Alien::Build::Plugin::$name";
     $pm    = "Alien/Build/Plugin/$name.pm";
     $pm    =~ s{::}{/}g;
   }
-  
+
   require $pm unless $class->can('new');
   my $plugin = $class->new(@args);
   $plugin->init($self);
@@ -1853,11 +1853,11 @@ be used by some Fetch plugins, if they support it.
 
 =head1 SUPPORT
 
-The intent of the C<Alien-Build> team is to support as best as possible 
-all Perls from 5.8.1 to the latest production version.  So long as they 
+The intent of the C<Alien-Build> team is to support as best as possible
+all Perls from 5.8.1 to the latest production version.  So long as they
 are also supported by the Perl toolchain.
 
-Please feel encouraged to report issues that you encounter to the 
+Please feel encouraged to report issues that you encounter to the
 project GitHub Issue tracker:
 
 =over 4
@@ -1866,7 +1866,7 @@ project GitHub Issue tracker:
 
 =back
 
-Better if you can fix the issue yourself, please feel encouraged to open 
+Better if you can fix the issue yourself, please feel encouraged to open
 pull-request on the project GitHub:
 
 =over 4
@@ -1875,8 +1875,8 @@ pull-request on the project GitHub:
 
 =back
 
-If you are confounded and have questions, join us on the C<#native> 
-channel on irc.perl.org.  The C<Alien-Build> developers frequent this 
+If you are confounded and have questions, join us on the C<#native>
+channel on irc.perl.org.  The C<Alien-Build> developers frequent this
 channel and can probably help point you in the right direction.  If you
 don't have an IRC client handy, you can use this web interface:
 

--- a/lib/Alien/Build/CommandSequence.pm
+++ b/lib/Alien/Build/CommandSequence.pm
@@ -89,14 +89,14 @@ sub _run_string
 {
   my($build, $cmd) = @_;
   $build->log("+ $cmd");
-  
+
   {
     my $cmd = $cmd;
     $cmd =~ s{\\}{\\\\}g if $^O eq 'MSWin32';
     my @cmd = shellwords($cmd);
     return $built_in{$cmd[0]}->(@cmd) if $built_in{$cmd[0]};
   }
-  
+
   system $cmd;
   die "external command failed" if $?;
 }
@@ -107,7 +107,7 @@ sub _run_with_code
   my $code = pop @cmd;
   $build->log("+ @cmd");
   my %args = ( command => \@cmd );
-  
+
   if($built_in{$cmd[0]})
   {
     my $error;
@@ -153,7 +153,7 @@ sub execute
   my $intr = $build->meta->interpolator;
 
   my $prop = $build->_command_prop;
-  
+
   foreach my $command (@{ $self->{commands} })
   {
     if(ref($command) eq 'CODE')
@@ -164,7 +164,7 @@ sub execute
     {
       my($command, @args) = @$command;
       my $code = pop @args if $args[-1] && ref($args[-1]) eq 'CODE';
-      
+
       if($args[-1] && ref($args[-1]) eq 'SCALAR')
       {
         my $dest = ${ pop @args };
@@ -185,9 +185,9 @@ sub execute
           die "illegal destination: $dest";
         }
       }
-      
+
       ($command, @args) = map { $intr->interpolate($_, $prop) } ($command, @args);
-      
+
       if($code)
       {
         _run_with_code $build, $command, @args, $code;

--- a/lib/Alien/Build/Interpolate.pm
+++ b/lib/Alien/Build/Interpolate.pm
@@ -42,7 +42,7 @@ sub add_helper
     require Carp;
     Carp::croak("duplicate implementation for interpolated key $name");
   }
-  
+
   while(@_)
   {
     my $module = shift;
@@ -50,7 +50,7 @@ sub add_helper
     $version ||= 0;
     $self->{helper}->{$name}->{require}->{$module} = $version;
   }
-  
+
   $self->{helper}->{$name}->{code} = $code;
 }
 
@@ -104,9 +104,9 @@ sub has_helper
       $self->{classes}->{$module} = 1;
     }
   }
-  
+
   my $code = $self->{helper}->{$name}->{code};
-  
+
   return unless defined $code;
 
   if(ref($code) ne 'CODE')
@@ -119,7 +119,7 @@ sub has_helper
       $value;
     };
   }
-  
+
   $code;
 }
 
@@ -132,10 +132,10 @@ sub has_helper
 sub execute_helper
 {
   my($self, $name) = @_;
-  
+
   my $code = $self->has_helper($name);
   die "no helper defined for $name" unless defined $code;
-  
+
   $code->();
 }
 
@@ -148,9 +148,9 @@ sub execute_helper
 sub _get_prop
 {
   my($name, $prop, $orig) = @_;
-  
+
   $name =~ s/^\./alien./;
-  
+
   if($name =~ /^(.*?)\.(.*)$/)
   {
     my($key,$rest) = ($1,$2);
@@ -171,7 +171,7 @@ sub interpolate
 {
   my($self, $string, $prop) = @_;
   $prop ||= {};
-  
+
   $string =~ s{(?<!\%)\%\{([a-zA-Z_][a-zA-Z_0-9]+)\}}{$self->execute_helper($1)}eg;
   $string =~ s{(?<!\%)\%\{([a-zA-Z_\.][a-zA-Z_0-9\.]+)\}}{_get_prop($1,$prop,$1)}eg;
   $string =~ s/\%(?=\%)//g;
@@ -202,9 +202,9 @@ sub requires
 sub clone
 {
   my($self) = @_;
-  
+
   require Storable;
-  
+
   my %help;
   foreach my $helper (keys %{ $self->{helper} })
   {

--- a/lib/Alien/Build/MM.pm
+++ b/lib/Alien/Build/MM.pm
@@ -16,9 +16,9 @@ In your Makefile.PL:
 
  use ExtUtils::MakeMaker;
  use Alien::Build::MM;
- 
+
  my $abmm = Alien::Build::MM->new;
- 
+
  WriteMakefile($abmm->mm_args(
    ABSTRACT     => 'Discover or download and install libfoo',
    DISTNAME     => 'Alien-Libfoo',
@@ -26,7 +26,7 @@ In your Makefile.PL:
    VERSION_FROM => 'lib/Alien/Libfoo.pm',
    ...
  ));
- 
+
  sub MY::postamble {
    $abmm->mm_postamble;
  }
@@ -54,9 +54,9 @@ Create a new instance of L<Alien::Build::MM>.
 sub new
 {
   my($class, %prop) = @_;
-  
+
   my $self = bless {}, $class;
-  
+
   my %meta = map { $_ => $prop{$_} } grep /^my_/, keys %prop;
 
   my $build = $self->{build} =
@@ -66,13 +66,13 @@ sub new
       meta_prop => \%meta,
     )
   ;
-  
+
   if(%meta)
   {
     $build->meta->add_requires(configure => 'Alien::Build::MM' => '1.20');
     $build->meta->add_requires(configure => 'Alien::Build' => '1.20');
   }
-  
+
   if(defined $prop{alienfile_meta})
   {
     $self->{alienfile_meta} = $prop{alienfile_meta};
@@ -81,7 +81,7 @@ sub new
   {
     $self->{alienfile_meta} = 1;
   }
-  
+
   $self->build->load_requires('configure');
   $self->build->root;
   $self->build->checkpoint;
@@ -130,7 +130,7 @@ Adjust the arguments passed into C<WriteMakefile> as needed by L<Alien::Build>.
 sub mm_args
 {
   my($self, %args) = @_;
-  
+
   if($args{DISTNAME})
   {
     $self->build->set_stage(Path::Tiny->new("blib/lib/auto/share/dist/$args{DISTNAME}")->absolute->stringify);
@@ -161,9 +161,9 @@ sub mm_args
   {
     Carp::croak "DISTNAME is required";
   }
-  
+
   my $ab_version = '0.25';
-  
+
   $args{CONFIGURE_REQUIRES} = Alien::Build::_merge(
     'Alien::Build::MM' => $ab_version,
     %{ $args{CONFIGURE_REQUIRES} || {} },
@@ -190,15 +190,15 @@ sub mm_args
   {
     die "unknown install type: @{[ $self->build->install_type ]}"
   }
-  
+
   $args{PREREQ_PM} = Alien::Build::_merge(
     'Alien::Build' => $ab_version,
     %{ $args{PREREQ_PM} || {} },
   );
- 
+
   #$args{META_MERGE}->{'meta-spec'}->{version} = 2;
   $args{META_MERGE}->{dynamic_config} = 1;
-  
+
   if($self->alienfile_meta)
   {
     $args{META_MERGE}->{x_alienfile} = {
@@ -212,7 +212,7 @@ sub mm_args
       },
     };
   }
-  
+
   $self->build->checkpoint;
   %args;
 }
@@ -248,16 +248,16 @@ system or share install).
 
 Prints the meta, install and runtime properties for the Alien.
 
-=back 
+=back
 
 =cut
 
 sub mm_postamble
 {
   my($self) = @_;
-  
+
   my $postamble = '';
-  
+
   # remove the _alien directory on a make realclean:
   $postamble .= "realclean :: alien_realclean\n" .
                 "\n" .
@@ -288,14 +288,14 @@ sub mm_postamble
   $postamble .= "alien_build : _alien/mm/build\n\n" .
                 "_alien/mm/build : _alien/mm/download\n" .
                 "\t\$(FULLPERL) -MAlien::Build::MM=cmd -e build\n\n";
-  
+
   # append to all
   $postamble .= "pure_all :: _alien/mm/build\n\n";
-  
+
   $postamble .= "subdirs-test_dynamic :: alien_test\n\n";
   $postamble .= "alien_test :\n" .
                 "\t\$(FULLPERL) -MAlien::Build::MM=cmd -e test\n\n";
-  
+
   # prop
   $postamble .= "alien_prop :\n" .
                 "\t\$(FULLPERL) -MAlien::Build::MM=cmd -e dumpprop\n\n";
@@ -305,7 +305,7 @@ sub mm_postamble
                 "\t\$(FULLPERL) -MAlien::Build::MM=cmd -e dumpprop install\n\n";
   $postamble .= "alien_prop_runtime :\n" .
                 "\t\$(FULLPERL) -MAlien::Build::MM=cmd -e dumpprop install\n\n";
-  
+
   $postamble;
 }
 
@@ -317,7 +317,7 @@ sub import
     if($arg eq 'cmd')
     {
       package main;
-      
+
       *_args = sub
       {
         my $build = Alien::Build->resume('alienfile', '_alien');
@@ -325,14 +325,14 @@ sub import
         $build->load_requires($build->install_type);
         ($build, @ARGV)
       };
-      
+
       *_touch = sub {
         my($name) = @_;
         my $path = Path::Tiny->new("_alien/mm/$name");
         $path->parent->mkpath;
         $path->touch;
       };
-      
+
       *prefix = sub
       {
         my($build, $type, $perl, $site, $vendor) = _args();
@@ -353,16 +353,16 @@ sub import
         $build->checkpoint;
         _touch('prefix');
       };
-      
+
       *version = sub
       {
         my($build, $version) = _args();
-        
+
         $build->runtime_prop->{perl_module_version} = $version;
         $build->checkpoint;
         _touch('version');
       };
-      
+
       *download = sub
       {
         my($build) = _args();
@@ -370,11 +370,11 @@ sub import
         $build->checkpoint;
        _touch('download');
       };
-      
+
       *build = sub
       {
         my($build) = _args();
-        
+
         $build->build;
 
         my $distname = $build->install_prop->{mm}->{distname};
@@ -386,10 +386,10 @@ sub import
           my $archfile = $archdir->child($archdir->basename . '.txt');
           $archfile->spew('Alien based distribution with architecture specific file in share');
         }
-        
+
         my $cflags = $build->runtime_prop->{cflags};
         my $libs   = $build->runtime_prop->{libs};
-        
+
         if(($cflags && $cflags !~ /^\s*$/)
         || ($libs   && $libs   !~ /^\s*$/))
         {
@@ -409,28 +409,28 @@ sub import
             "=cut\n",
           );
         }
-        
+
         $build->checkpoint;
         _touch('build');
       };
-      
+
       *test = sub
       {
         my($build) = _args();
         $build->test;
         $build->checkpoint;
       };
-      
+
       *dumpprop = sub
       {
         my($build, $type) = _args();
-        
+
         my %h = (
           meta    => $build->meta_prop,
           install => $build->install_prop,
           runtime => $build->runtime_prop,
         );
-        
+
         require Alien::Build::Util;
         print Alien::Build::Util::_dump($type ? $h{$type} : \%h);
       }

--- a/lib/Alien/Build/Manual/AlienAuthor.pod
+++ b/lib/Alien/Build/Manual/AlienAuthor.pod
@@ -8,128 +8,128 @@
 
 =head1 DESCRIPTION
 
-This document is intended to teach L<Alien> authors how to build their 
-own L<Alien> distribution using L<Alien::Build> and L<Alien::Base>.  
+This document is intended to teach L<Alien> authors how to build their
+own L<Alien> distribution using L<Alien::Build> and L<Alien::Base>.
 Such an L<Alien> distribution consists of three essential parts:
 
 =over 4
 
 =item An L<alienfile>
 
-This is a recipe for how to 1) detect an already installed version of 
-the library or tool you are alienizing 2) download and build the library 
-or tool that you are alienizing and 3) gather the configuration settings 
+This is a recipe for how to 1) detect an already installed version of
+the library or tool you are alienizing 2) download and build the library
+or tool that you are alienizing and 3) gather the configuration settings
 necessary for the use of that library or tool.
 
 =item An installer C<Makefile.PL> or C<Build.PL> or a C<dist.ini> if you are using L<Dist::Zilla>
 
-This is a thin layer between your L<alienfile> recipe, and the Perl 
+This is a thin layer between your L<alienfile> recipe, and the Perl
 installer (either L<ExtUtils::MakeMaker> or L<Module::Build>.
 
 =item A Perl class (.pm file) that inherits from L<Alien::Base>
 
-For most L<Alien>s this does not need to be customized at all, since 
+For most L<Alien>s this does not need to be customized at all, since
 L<Alien::Base> usually does what you need.
 
 =back
 
-For example if you were alienizing a library called libfoo, you might 
+For example if you were alienizing a library called libfoo, you might
 have these files:
 
  Alien-Libfoo-1.00/Makefile.PL
  Alien-Libfoo-1.00/alienfile
  Alien-Libfoo-1.00/lib/Alien/Libfoo.pm
 
-This document will focus mainly on instructing you how to construct an 
-L<alienfile>, but we will also briefly cover making a simple 
-C<Makefile.PL> or C<dist.ini> to go along with it.  We will also touch 
-on when you might want to extend your subclass to add non-standard 
+This document will focus mainly on instructing you how to construct an
+L<alienfile>, but we will also briefly cover making a simple
+C<Makefile.PL> or C<dist.ini> to go along with it.  We will also touch
+on when you might want to extend your subclass to add non-standard
 functionality.
 
 =head2 Using commands
 
-Most software libraries and tools will come with instructions for how to 
-install them in the form of commands that you are intended to type into 
-a shell manually.  The easiest way to automate those instructions is to 
-just put the commands in your L<alienfile>.  For example, lets suppose 
+Most software libraries and tools will come with instructions for how to
+install them in the form of commands that you are intended to type into
+a shell manually.  The easiest way to automate those instructions is to
+just put the commands in your L<alienfile>.  For example, lets suppose
 that libfoo is built using autoconf and provides a C<pkg-config> C<.pc>
 file.
 
-(Aside, autoconf is a series of tools and macros used to configure 
-(usually) a C or C++ library or tool by generating any number of 
-Makefiles.  It is the C equivalent to L<ExtUtils::MakeMaker>, if you 
-will.  Basically, if your library or tool instructions start with 
+(Aside, autoconf is a series of tools and macros used to configure
+(usually) a C or C++ library or tool by generating any number of
+Makefiles.  It is the C equivalent to L<ExtUtils::MakeMaker>, if you
+will.  Basically, if your library or tool instructions start with
 './configure' it is most likely an autoconf based library or tool).
 
-(Aside2, C<pkg-config> is a standard-ish way to provide the compiler and 
-linker flags needed for compiling and linking against the library.  If 
-your tool installs a C<.pc> file, usually in C<$PREFIX/lib/pkgconfig> 
+(Aside2, C<pkg-config> is a standard-ish way to provide the compiler and
+linker flags needed for compiling and linking against the library.  If
+your tool installs a C<.pc> file, usually in C<$PREFIX/lib/pkgconfig>
 then, your tool uses C<pkg-config>).
 
 Here is the L<alienfile> that you might have:
 
  use alienfile;
- 
+
  probe [ 'pkg-config --exists libfoo' ];
- 
+
  share {
-   
+
    start_url 'http://www.libfoo.org/src/libfoo-1.00.tar.gz';
-   
+
    download [ 'wget %{.meta.start_url}' ];
-   
+
    extract [ 'tar zxf %{.install.download}' ];
-   
+
    build [
      [ './configure --prefix=%{.install.prefix} --disable-shared' ],
      [ '%{make}' ],
      [ '%{make} install' ],
    ];
-   
+
  };
- 
+
  gather [
    [ 'pkg-config --modversion libfoo', \'%{.runtime.version}' ],
    [ 'pkg-config --cflags     libfoo', \'%{.runtime.cflags}'  ],
    [ 'pkg-config --libs       libfoo', \'%{.runtime.libs}'    ],
  ];
 
-There is a lot going on here, so lets decode it a little bit.  An 
-L<alienfile> is just some Perl with some alien specific sugar.  The 
+There is a lot going on here, so lets decode it a little bit.  An
+L<alienfile> is just some Perl with some alien specific sugar.  The
 first line
 
  use alienfile;
 
-imports the sugar into the L<alienfile>.  It also is a flag for the 
-reader to see that this is an L<alienfile> and not some other kind of 
+imports the sugar into the L<alienfile>.  It also is a flag for the
+reader to see that this is an L<alienfile> and not some other kind of
 Perl script.
 
 The second line is the probe directive:
 
  probe [ 'pkg-config --exists libfoo' ];
 
-is used to see if the library is already installed on the target system.  
-If C<pkg-config> is in the path, and if libfoo is installed, this should 
-exit with a success (0) and tell L<Alien::Build> to use the system 
-library.  If either C<pkg-config> in the PATH, or if libfoo is not 
-installed, then it will exist with non-success (!= 0) and tells 
+is used to see if the library is already installed on the target system.
+If C<pkg-config> is in the path, and if libfoo is installed, this should
+exit with a success (0) and tell L<Alien::Build> to use the system
+library.  If either C<pkg-config> in the PATH, or if libfoo is not
+installed, then it will exist with non-success (!= 0) and tells
 L<Alien::Build> to download and build from source.
 
-You can provide as many probe directives as you want.  This is useful if 
-there are different ways to probe for the system.  L<Alien::Build> will 
-stop on the first successfully found system library found.  Say our 
-library libfoo comes with a C<.pc> file for use with C<pkg-config> and 
-also provides a C<foo-config> program to find the same values.  You 
+You can provide as many probe directives as you want.  This is useful if
+there are different ways to probe for the system.  L<Alien::Build> will
+stop on the first successfully found system library found.  Say our
+library libfoo comes with a C<.pc> file for use with C<pkg-config> and
+also provides a C<foo-config> program to find the same values.  You
 could then specify this in your L<alienfile>
 
  probe [ 'pkg-config --exists libfoo' ];
  probe [ 'foo-config --version' ];
 
-Other directives can be specified multiple times if there are different 
+Other directives can be specified multiple times if there are different
 methods that can be tried for the various steps.
 
-Sometimes it is easier to probe for a library from Perl rather than with 
-a command.  For that you can use a code reference.  For example, another 
+Sometimes it is easier to probe for a library from Perl rather than with
+a command.  For that you can use a code reference.  For example, another
 way to call C<pkg-config> would be from Perl:
 
  probe sub {
@@ -138,13 +138,13 @@ way to call C<pkg-config> would be from Perl:
    $? == 0 ? 'system' : 'share';
  };
 
-The Perl code should return 'system' if the library is installed, and 
-'share' if not.  (Other directives should return a true value on 
-success, and a false value).  You can also throw an exception with 
+The Perl code should return 'system' if the library is installed, and
+'share' if not.  (Other directives should return a true value on
+success, and a false value).  You can also throw an exception with
 C<die> to indicate a failure.
 
-The next part of the L<alienfile> is the C<share> block, which is used 
-to group the directives which are used to download and install the 
+The next part of the L<alienfile> is the C<share> block, which is used
+to group the directives which are used to download and install the
 library or tool in the event that it is not already installed.
 
  share {
@@ -163,8 +163,8 @@ It should be either a tarball (or zip file, or what have you) or an
 HTML index.  The download directive as you might imagine specifies how
 to download  the library or tool.  The extract directive specifies how
 to extract the archive once it is downloaded.  In the extract step, you
-can use the variable C<%{.install.download}> as a placeholder for the archive 
-that was downloaded in the download step.  This is also accessible if 
+can use the variable C<%{.install.download}> as a placeholder for the archive
+that was downloaded in the download step.  This is also accessible if
 you use a code reference from the L<Alien::Build> instance:
 
  share {
@@ -180,16 +180,16 @@ you use a code reference from the L<Alien::Build> instance:
    ...
  };
 
-The build directive specifies how to build the library or tool once it 
-has been downloaded and extracted.  Note the special variable 
-C<%{.install.prefix}> is the location where the library should be 
-installed.  C<%{make}> is a helper which will be replaced by the 
-appropriate C<make>, which may be called something different on some 
-platforms (on Windows for example, it frequently may be called C<nmake> 
+The build directive specifies how to build the library or tool once it
+has been downloaded and extracted.  Note the special variable
+C<%{.install.prefix}> is the location where the library should be
+installed.  C<%{make}> is a helper which will be replaced by the
+appropriate C<make>, which may be called something different on some
+platforms (on Windows for example, it frequently may be called C<nmake>
 or C<dmake>).
 
-The final part of the L<alienfile> has a gather directive which 
-specifies how to get the details on how to compile and link against the 
+The final part of the L<alienfile> has a gather directive which
+specifies how to get the details on how to compile and link against the
 library.  For this, once again we use the C<pkg-config> command:
 
  gather [
@@ -198,16 +198,16 @@ library.  For this, once again we use the C<pkg-config> command:
    [ 'pkg-config --libs       libfoo', \'%{.runtime.libs}'    ],
  ];
 
-The scalar reference as the final item in the command list tells 
-L<Alien::Build> that the output from the command should be stored in the 
-given variable.  The runtime variables are the ones that will be 
-available to C<Alien::Libfoo> once it is installed.  (Install 
-properties, which are the ones that we have seen up till now are thrown 
+The scalar reference as the final item in the command list tells
+L<Alien::Build> that the output from the command should be stored in the
+given variable.  The runtime variables are the ones that will be
+available to C<Alien::Libfoo> once it is installed.  (Install
+properties, which are the ones that we have seen up till now are thrown
 away once the L<Alien> distribution is installed.
 
-You can also provide a C<sys> block for directives that should be used 
-when a system install is detected.  Normally you only need to do this if 
-the gather step is different between share and system installs.  For 
+You can also provide a C<sys> block for directives that should be used
+when a system install is detected.  Normally you only need to do this if
+the gather step is different between share and system installs.  For
 example, the above is equivalent to:
 
  build {
@@ -218,7 +218,7 @@ example, the above is equivalent to:
      [ 'pkg-config --libs       libfoo', \'%{.runtime.libs}'    ],
    ];
  };
- 
+
  sys {
    gather [
      [ 'pkg-config --modversion libfoo', \'%{.runtime.version}' ],
@@ -227,29 +227,29 @@ example, the above is equivalent to:
    ];
  };
 
-(Aside3, the reason it is called C<sys> and not C<system> is so that it 
+(Aside3, the reason it is called C<sys> and not C<system> is so that it
 does not conflict with the built in C<system> function)!
 
 =head2 Using plugins
 
-The first example is a good way of showing the full manual path that you 
-can choose, but there is a lot of repetition, if you are doing many 
-L<Alien>s that use autoconf and C<pkg-config> (which are quite common.  
+The first example is a good way of showing the full manual path that you
+can choose, but there is a lot of repetition, if you are doing many
+L<Alien>s that use autoconf and C<pkg-config> (which are quite common.
 L<alienfile> allows you to use plugins.  See L<Alien::Build::Plugin> for
 a list of some of the plugin categories.
 
-For now, I will just show you how to write the L<alienfile> for libfoo 
-above using L<Alien::Build::Plugin::Build::Autoconf>, 
-L<Alien::Build::Plugin::PkgConfig::Negotiate>, 
+For now, I will just show you how to write the L<alienfile> for libfoo
+above using L<Alien::Build::Plugin::Build::Autoconf>,
+L<Alien::Build::Plugin::PkgConfig::Negotiate>,
 L<Alien::Buld::Plugin::Download::Negotiate>, and
 L<Alien::Build::Plugin::Extract::Negotiate>
 
  use alienfile;
- 
+
  plugin 'PkgConfig' => (
    pkg_name => 'libfoo',
  );
- 
+
  share {
    start_url 'http://www.libfoo.org/src';
    plugin 'Download' => (
@@ -265,34 +265,34 @@ L<Alien::Build::Plugin::Extract::Negotiate>
    ];
  };
 
-The first plugin that we use is the C<pkg-config> negotiation plugin.  A 
-negotiation plugin is one which doesn't do the actual work but selects 
-the best one from a set of plugins depending on your platform and 
-environment.  (In the case of 
-L<Alien::Build::Plugin::PkgConfig::Negotiate>, it may choose to use 
-command line tools, a pure Perl implementation (L<PkgConfig>), or 
-libpkgconf, depending on what is available).  When using negotiation 
-plugins you may omit the C<::Negotiate> suffix.  So as you can see using 
-the plugin here is an advantage because it is more reliable that just 
+The first plugin that we use is the C<pkg-config> negotiation plugin.  A
+negotiation plugin is one which doesn't do the actual work but selects
+the best one from a set of plugins depending on your platform and
+environment.  (In the case of
+L<Alien::Build::Plugin::PkgConfig::Negotiate>, it may choose to use
+command line tools, a pure Perl implementation (L<PkgConfig>), or
+libpkgconf, depending on what is available).  When using negotiation
+plugins you may omit the C<::Negotiate> suffix.  So as you can see using
+the plugin here is an advantage because it is more reliable that just
 specifying a command which may not be installed!
 
-Next we use the download negotiation plugin.  This is also better than 
-the version above, because again, C<wget> my not be installed on the 
-target system.  Also you can specify a URL which will be scanned for 
+Next we use the download negotiation plugin.  This is also better than
+the version above, because again, C<wget> my not be installed on the
+target system.  Also you can specify a URL which will be scanned for
 links, and use the most recent version.
 
-We use the Extract negotiation plugin to use either command line tools, 
+We use the Extract negotiation plugin to use either command line tools,
 or Perl libraries to extract from the archive once it is downloaded.
 
-Finally we use the Autoconf plugin 
-(L<Alien::Build::Plugin::Build::Autoconf>).  This is a lot more 
-sophisticated and reliable than in the previous example, for a number of 
-reasons.  This version will even work on Windows assuming the library or 
+Finally we use the Autoconf plugin
+(L<Alien::Build::Plugin::Build::Autoconf>).  This is a lot more
+sophisticated and reliable than in the previous example, for a number of
+reasons.  This version will even work on Windows assuming the library or
 tool you are alienizing supports that platform!
 
-Strictly speaking the build directive is not necessary, because the 
-autoconf plugin provides a default which is reasonable.  The only reason 
-that you would want to include it is if you need to provide additional 
+Strictly speaking the build directive is not necessary, because the
+autoconf plugin provides a default which is reasonable.  The only reason
+that you would want to include it is if you need to provide additional
 flags to the configure step.
 
  share {
@@ -306,12 +306,12 @@ flags to the configure step.
 
 =head2 Verifying and debugging your alienfile
 
-You could feed your alienfile directly into L<Alien::Build>, or 
-L<Alien::Build::MM>, but it is sometimes useful to test your alienfile 
-using the C<af> command (it does not come with L<Alien::Build>, you need 
-to install L<App::af>).  By default C<af> will use the C<alienfile> in 
-the current directly (just as C<make> uses the C<Makefile> in the 
-current directory; just like C<make> you can use the C<-f> option to 
+You could feed your alienfile directly into L<Alien::Build>, or
+L<Alien::Build::MM>, but it is sometimes useful to test your alienfile
+using the C<af> command (it does not come with L<Alien::Build>, you need
+to install L<App::af>).  By default C<af> will use the C<alienfile> in
+the current directly (just as C<make> uses the C<Makefile> in the
+current directory; just like C<make> you can use the C<-f> option to
 specify a different L<alienfile>).
 
 You can test your L<alienfile> in dry run mode:
@@ -334,7 +334,7 @@ You can test your L<alienfile> in dry run mode:
  prefix: /tmp/7RtAusykNN
  version: 1.2.3
 
-You can use the C<--type> option to force a share install (download and 
+You can use the C<--type> option to force a share install (download and
 build from source):
 
  % af install --type=share --dry-run
@@ -367,8 +367,8 @@ build from source):
  prefix: /tmp/P22WEXj80r
  version: 1.2.4
 
-You can also use the C<--before> and C<--after> options to take a peek 
-at what the build environment looks like at different stages as well, 
+You can also use the C<--before> and C<--after> options to take a peek
+at what the build environment looks like at different stages as well,
 which can sometimes be useful:
 
  % af install --dry-run --type=share --before build bash
@@ -387,9 +387,9 @@ which can sometimes be useful:
  App::af::install>  [ before build ] + bash
  /tmp/fbVPu4LRTs/build_5AVn/libfoo-1.2.4$ ls
  CHANGES Makefile autoconf.ac lib
- /tmp/fbVPu4LRTs/build_5AVn/libfoo-1.2.4$ 
+ /tmp/fbVPu4LRTs/build_5AVn/libfoo-1.2.4$
 
-There are a lot of other useful things that you can do with the C<af> 
+There are a lot of other useful things that you can do with the C<af>
 command.  See L<af> for details.
 
 =head2 Integrating with MakeMaker
@@ -398,16 +398,16 @@ Once you have a working L<alienfile> you can write your C<Makefile.PL>.
 
  use ExtUtils::MakeMaker;
  use Alien::Build::MM;
- 
+
  my $abmm = Alien::Build::MM->new;
- 
+
  WriteMakefile($abmm->mm_args(
    ABSTRACT => 'Discover or download and install libfoo',
    DISTNAME => 'Alien-Libfoo',
    NAME     => 'Alien::Libfoo',
    VERSION_FROM => 'lib/Alien/Libfoo.pm',
  ));
- 
+
  sub MY::postamble {
    $abmm->mm_postamble;
  }
@@ -415,11 +415,11 @@ Once you have a working L<alienfile> you can write your C<Makefile.PL>.
 The C<lib/Alien/Libfoo.pm> that goes along with it is very simple:
 
  package Alien::Libfoo;
- 
+
  use strict;
  use warnings;
  use base qw( Alien::Base );
- 
+
  1;
 
 You are done and can install it normally:
@@ -435,10 +435,10 @@ Please don't!  Okay if you have to there is L<Alien::Build::MB>.
 
 =head2 Non standard configuration
 
-L<Alien::Base> support most of the things that your L<Alien> will need, 
-like compiler flags (cflags), linker flags (libs) and binary directory 
-(bin_dir).  Your library or tool may have other configuration items 
-which are not supported by default.  You can store the values in the 
+L<Alien::Base> support most of the things that your L<Alien> will need,
+like compiler flags (cflags), linker flags (libs) and binary directory
+(bin_dir).  Your library or tool may have other configuration items
+which are not supported by default.  You can store the values in the
 L<alienfile> into the runtime properties:
 
  gather [
@@ -453,45 +453,45 @@ L<alienfile> into the runtime properties:
 then you can expose them in your L<Alien::Base> subclass:
 
  package Alien::Libfoo;
- 
+
  use strict;
  use warnings;
  use base qw( Alien::Base );
- 
+
  sub bar_baz {
    my($self) = @_;
    $self->runtime_prop->{bar_baz},
  };
- 
+
  1;
 
 =head2 Testing
 
 (optional, but highly recommended)
 
-You should write a test using L<Test::Alien> to make sure that your 
+You should write a test using L<Test::Alien> to make sure that your
 alien will work with any XS modules that are going to use it:
 
  use Test2::V0;
  use Test::Alien;
  use Alien::Libfoo;
- 
+
  alien_ok 'Alien::Libfoo';
- 
+
  xs_ok { local $/; <DATA> }, with_subtest {
    is Foo::something(), 1, 'Foo::something() returns 1';
  };
- 
+
  done_testing;
- 
+
  __DATA__
  #include "EXTERN.h"
  #include "perl.h"
  #include "XSUB.h"
  #include <foo.h>
- 
+
  MODULE = Foo PACKAGE = Foo
- 
+
  int something(class)
 
 You can also use L<Test::Alien> to test tools instead of libraries:
@@ -499,14 +499,14 @@ You can also use L<Test::Alien> to test tools instead of libraries:
  use Test2::V0;
  use Test::Alien;
  use Alien::Libfoo;
- 
+
  alien_ok 'Alien::Libfoo';
  run_ok('foo', '--version')
    ->exit_is(0);
- 
+
  done_testing;
 
-More details on testing L<Alien> modules can be found in the 
+More details on testing L<Alien> modules can be found in the
 L<Test::Alien> documentation.
 
 You can also run the tests that come with the package that you are alienizing,
@@ -517,9 +517,9 @@ blindly add a test block without checking what the prereqs are.  For Autoconf
 style packages you typically test a package using the C<make check> command:
 
  use alienfile;
- 
+
  plugin 'PkgConfig' => 'libfoo';
- 
+
  share {
    ... # standard build steps.
    test [ '%{make} check' ];
@@ -542,13 +542,13 @@ L<Dist::Zilla::Plugin::AlienBuild>:
  [@Basic]
  [AlienBuild]
 
-The plugin takes care of a lot of details like making sure that the 
-correct minimum versions of L<Alien::Build> and L<Alien::Base> are used.  
+The plugin takes care of a lot of details like making sure that the
+correct minimum versions of L<Alien::Build> and L<Alien::Base> are used.
 See the plugin documentation for additional details.
 
 =head2 Using your Alien
 
-Once you have installed you can use your Alien.  See 
+Once you have installed you can use your Alien.  See
 L<Alien::Build::Manual::AlienUser> for guidance on that.
 
 =cut

--- a/lib/Alien/Build/Manual/AlienUser.pod
+++ b/lib/Alien/Build/Manual/AlienUser.pod
@@ -35,7 +35,7 @@ What follows are the main use cases.
  use Module::Build;
  use Alien::Base::Wrapper qw( Alien::Foo !export );
  use Alien::Foo;
- 
+
  my $build = Module::Build->new(
    ...
    configure_requires => {
@@ -46,18 +46,18 @@ What follows are the main use cases.
    Alien::Base::Wrapper->mb_args
    ...
  );
- 
+
  $build->create_build_script;
 
 The key gotcha for using L<Alien> from a C<Build.PL> for an XS module
-is remembering to explicitly making the L<Alien> a configuration 
+is remembering to explicitly making the L<Alien> a configuration
 prerequisite.
 
 =head2 ExtUtils::MakeMaker
 
  use ExtUtils::MakeMaker;
  use Alien::Base::Wrapper qw( Alien::Foo !export );
- 
+
  WriteMakefile(
    ...
    CONFIGURE_REQUIRES => {
@@ -76,10 +76,10 @@ a configure prerequisite.
  [@Filter]
  -bundle = @Basic
  -remove = MakeMaker
- 
+
  [Prereqs / ConfigureRequires]
  Alien::Foo = 0
- 
+
  [MakeMaker::Awesome]
  header = use Alien::Base::Wrapper qw( Alien::Foo !export );
  WriteMakefile_arg = Alien::Base::Wrapper->mm_args
@@ -88,7 +88,7 @@ a configure prerequisite.
 
  use FFI::Platypus;
  use Alien::Foo;
- 
+
  my $ffi = FFI::Platypus->new(
    lib => [ Alien::Foo->dynamic_libs ],
  );
@@ -102,13 +102,13 @@ need to be a regular run time prerequisite.
  use Inline with => 'Alien::Foo';
  use Inline C => <<~'END';
    #include <foo.h>
-   
+
    const char *my_foo_wrapper()
    {
      foo();
    }
    END
- 
+
  sub exported_foo()
  {
    my_foo_wrapper();
@@ -118,7 +118,7 @@ need to be a regular run time prerequisite.
 
  use Alien::Foo;
  use Env qw( @PATH );
- 
+
  unshift @ENV, Alien::Foo->bin_dir;
  system 'foo', '--bar', '--baz';
 

--- a/lib/Alien/Build/Manual/Contributing.pod
+++ b/lib/Alien/Build/Manual/Contributing.pod
@@ -8,122 +8,122 @@
 
 =head1 DESCRIPTION
 
-Thank you for considering to contribute to my open source project!  If 
-you have a small patch please consider just submitting it.  Doing so 
+Thank you for considering to contribute to my open source project!  If
+you have a small patch please consider just submitting it.  Doing so
 through the project GitHub is probably the best way:
 
 L<https://github.com/plicease/Alien-Build/issues>
 
-If you have a more invasive enhancement or bugfix to contribute, please 
-take the time to review these guidelines.  In general it is good idea to 
-work closely with the L<Alien::Build> developers, and the best way to 
+If you have a more invasive enhancement or bugfix to contribute, please
+take the time to review these guidelines.  In general it is good idea to
+work closely with the L<Alien::Build> developers, and the best way to
 contact them is on the C<#native> IRC channel on irc.perl.org.
 
 =head2 History
 
-Joel Berger wrote the original L<Alien::Base>.  This distribution 
-included the runtime code L<Alien::Base> and an installer class 
-L<Alien::Base::ModuleBuild>.  The significant thing about L<Alien::Base> 
-was that it provided tools to make it relatively easy for people to roll 
-their own L<Alien> distributions.  Over time, the Perl5-Alien (github 
-organization) or "Alien::Base team" has taken over development of 
-L<Alien::Base> with myself (Graham Ollis) being responsible for 
+Joel Berger wrote the original L<Alien::Base>.  This distribution
+included the runtime code L<Alien::Base> and an installer class
+L<Alien::Base::ModuleBuild>.  The significant thing about L<Alien::Base>
+was that it provided tools to make it relatively easy for people to roll
+their own L<Alien> distributions.  Over time, the Perl5-Alien (github
+organization) or "Alien::Base team" has taken over development of
+L<Alien::Base> with myself (Graham Ollis) being responsible for
 integration and releases.  Joel Berger is still involved in the project.
 
-Since the original development of L<Alien::Base>, L<Module::Build>, on 
-which L<Alien::Base::ModuleBuild> is based, has been removed from the 
-core of Perl.  It seemed worthwhile to write a replacement installer 
-that works with L<ExtUtils::MakeMaker> which IS still bundled with the 
-Perl core.  Because this is a significant undertaking it is my intention 
-to integrate the many lessons learned by Joel Berger, myself and the 
-"Alien::Base team" as possible.  If the interface seems good then it is 
+Since the original development of L<Alien::Base>, L<Module::Build>, on
+which L<Alien::Base::ModuleBuild> is based, has been removed from the
+core of Perl.  It seemed worthwhile to write a replacement installer
+that works with L<ExtUtils::MakeMaker> which IS still bundled with the
+Perl core.  Because this is a significant undertaking it is my intention
+to integrate the many lessons learned by Joel Berger, myself and the
+"Alien::Base team" as possible.  If the interface seems good then it is
 because I've stolen the ideas from some pretty good places.
 
 =head2 Philosophy
 
 =head3 avoid dependencies
 
-One of the challenges with L<Alien> development is that you are by the 
-nature of the problem, trying to make everyone happy.  Developers 
-working out of CPAN just want stuff to work, and some build environments 
-can be hostile in terms of tool availability, so for reliability you end 
-up pulling a lot of dependencies.  On the other hand, operating system 
-vendors who are building Perl modules usually want to use the system 
-version of a library so that they do not have to patch libraries in 
-multiple places.  Such vendors have to package any extra dependencies 
-and having to do so for packages that the don't even use makes them 
+One of the challenges with L<Alien> development is that you are by the
+nature of the problem, trying to make everyone happy.  Developers
+working out of CPAN just want stuff to work, and some build environments
+can be hostile in terms of tool availability, so for reliability you end
+up pulling a lot of dependencies.  On the other hand, operating system
+vendors who are building Perl modules usually want to use the system
+version of a library so that they do not have to patch libraries in
+multiple places.  Such vendors have to package any extra dependencies
+and having to do so for packages that the don't even use makes them
 understandably unhappy.
 
-As general policy the L<Alien::Build> core should have as few 
-dependencies as possible, and should only pull extra dependencies if 
-they are needed.  Where dependencies cannot be avoidable, popular and 
-reliable CPAN modules, which are already available as packages in the 
+As general policy the L<Alien::Build> core should have as few
+dependencies as possible, and should only pull extra dependencies if
+they are needed.  Where dependencies cannot be avoidable, popular and
+reliable CPAN modules, which are already available as packages in the
 major Linux vendors (Debian, Red Hat) should be preferred.
 
-As such L<Alien::Build> is hyper aggressive at using dynamic 
+As such L<Alien::Build> is hyper aggressive at using dynamic
 prerequisites.
 
 =head3 interface agnostic
 
-One of the challenges with L<Alien::Buil::ModuleBuild> was that 
-L<Module::Build> was pulled from the core.  In addition, there is a 
-degree of hostility toward L<Module::Build> in some corners of the Perl 
-community.  I agree with Joel Berger's rationale for choosing 
-L<Module::Build> at the time, as I believe its interface more easily 
+One of the challenges with L<Alien::Buil::ModuleBuild> was that
+L<Module::Build> was pulled from the core.  In addition, there is a
+degree of hostility toward L<Module::Build> in some corners of the Perl
+community.  I agree with Joel Berger's rationale for choosing
+L<Module::Build> at the time, as I believe its interface more easily
 lends itself to building L<Alien> distributions.
 
-That said, an important feature of L<Alien::Build> is that it is 
-installer agnostic.  Although it is initially designed to work with 
-L<ExtUtils::MakeMaker>, it has been designed from the ground up to work 
+That said, an important feature of L<Alien::Build> is that it is
+installer agnostic.  Although it is initially designed to work with
+L<ExtUtils::MakeMaker>, it has been designed from the ground up to work
 with any installer (Perl, or otherwise).
 
-As an extension of this, although L<Alien::Build> may have external CPAN 
-dependencies, they should not be exposed to developers USING 
-L<Alien::Build>.  As an example, L<Path::Tiny> is used heavily 
-internally because it does what L<File::Spec> does, plus the things that 
-it doesn't, and uses forward slashes on Windows (backslashes are the 
-"correct separator on windows, but actually using them tends to break 
-everything).  However, there aren't any interfaces in L<Alien::Build> 
-that will return a L<Path::Tiny> object (or if there are, then this is a 
+As an extension of this, although L<Alien::Build> may have external CPAN
+dependencies, they should not be exposed to developers USING
+L<Alien::Build>.  As an example, L<Path::Tiny> is used heavily
+internally because it does what L<File::Spec> does, plus the things that
+it doesn't, and uses forward slashes on Windows (backslashes are the
+"correct separator on windows, but actually using them tends to break
+everything).  However, there aren't any interfaces in L<Alien::Build>
+that will return a L<Path::Tiny> object (or if there are, then this is a
 bug).
 
-This means that if we ever need to port L<Alien::Build> to a platform 
-that doesn't support L<Path::Tiny> (such as VMS), then it may require 
-some work to L<Alien::Build> itself, modules that USE L<Alien::Build> 
+This means that if we ever need to port L<Alien::Build> to a platform
+that doesn't support L<Path::Tiny> (such as VMS), then it may require
+some work to L<Alien::Build> itself, modules that USE L<Alien::Build>
 shouldn't need to be modified.
 
 =head3 plugable
 
-The actual logic that probes the system, downloads source and builds it 
-should be as pluggable as possible.  One of the challenges with 
-L<Alien::Build::ModuleBuild> was that it was designed to work well with 
-software that works with C<autoconf> and C<pkg-config>.  While you can 
-build with other tools, you have to know a bit of how the installer 
+The actual logic that probes the system, downloads source and builds it
+should be as pluggable as possible.  One of the challenges with
+L<Alien::Build::ModuleBuild> was that it was designed to work well with
+software that works with C<autoconf> and C<pkg-config>.  While you can
+build with other tools, you have to know a bit of how the installer
 logic works, and which hooks need to be tweaked.
 
-L<Alien::Build> has plugins for C<autoconf>, C<pkgconf> (successor of 
-C<pkg-config>), vanilla Makefiles, and CMake.  If your build system 
-doesn't have a plugin, then all you have to do is write one!  Plugins 
-that prove their worth may be merged into the L<Alien::Build> core.  
-Plugins that after a while feel like maybe not such a good idea may be 
+L<Alien::Build> has plugins for C<autoconf>, C<pkgconf> (successor of
+C<pkg-config>), vanilla Makefiles, and CMake.  If your build system
+doesn't have a plugin, then all you have to do is write one!  Plugins
+that prove their worth may be merged into the L<Alien::Build> core.
+Plugins that after a while feel like maybe not such a good idea may be
 removed from the core, or even from CPAN itself.
 
-In addition, L<Alien::Build> has a special type of plugin, called a 
-negotiator which picks the best plugin for the particular environment 
-that it is running in.  This way, as development of the negotiator and 
-plugins develop over time modules that use L<Alien::Build> will benefit, 
+In addition, L<Alien::Build> has a special type of plugin, called a
+negotiator which picks the best plugin for the particular environment
+that it is running in.  This way, as development of the negotiator and
+plugins develop over time modules that use L<Alien::Build> will benefit,
 without having to change the way they interface with L<Alien::Build>
 
 =head1 ACKNOWLEDGEMENT
 
-I would like to that Joel Berger for getting things running in the first 
+I would like to that Joel Berger for getting things running in the first
 place.  Also important to thank other members of the "Alien::Base team":
 
 Zaki Mughal (SIVOAIS)
 
 Ed J (ETJ, mohawk)
 
-Also kind thanks to all of the developers who have contributed to 
+Also kind thanks to all of the developers who have contributed to
 L<Alien::Base> over the years:
 
 L<https://metacpan.org/pod/Alien::Base#CONTRIBUTORS>

--- a/lib/Alien/Build/Manual/FAQ.pod
+++ b/lib/Alien/Build/Manual/FAQ.pod
@@ -88,11 +88,11 @@ MSYS plugin and use a command sequence to do the build like this:
 =head3 CMake
 
 There is an alien L<Alien::cmake3> that provides C<cmake> 3.x or better (It is preferred to the
-older L<Alien::CMake>).  Though it is recommended that you use the C<cmake> 
+older L<Alien::CMake>).  Though it is recommended that you use the C<cmake>
 (L<Alien::Build::Plugin::Build::CMake>) plugin instead of using L<Alien::cmake3>.
 
  use alienfile;
- 
+
  share {
    plugin 'Build::CMake';
    build [
@@ -150,7 +150,7 @@ C<cflags> and C<libs> properties on either a C<system> or C<share> install.
 The various pkg-config plugins all support a minimum_version field:
 
  use alienfile;
- 
+
  plugin 'PkgConfig', pkg_name => foo, minimum_version => '1.2.3';
 
 =head2 How to create an Alien module for a packages that do not support pkg-config?
@@ -162,18 +162,18 @@ and linker flags.  For those packages you can just use the commands in your L<al
 Something like this:
 
  use alienfile;
- 
+
  probe [ 'foo-config --version' ];
- 
+
  share {
    ...
- 
+
    build [
      '%{make} PREFIX=%{.runtime.prefix}',
      '%{amek} install PREFIX=%{.runtime.prefix}',
    ];
  };
- 
+
  gather [
    [ 'foo-config', '--version', \'%{.runtime.version}' ],
    [ 'foo-config', '--cflags',  \'%{.runtime.cflags}'  ],
@@ -190,7 +190,7 @@ the C<cbuilder> plugin (L<Alien::Build::Plugin::Probe::CBuilder>.
    cflags => '-I/opt/libfoo/include',
    libs   => '-L/opt/libfoo/lib -lfoo',
  );
- 
+
  share {
    ...
    gather sub {
@@ -215,7 +215,7 @@ the L<Alien::Build> toolset.  A good example of how to do this is L<Alien::nasm>
 to use the 'Probe::CommandLine':
 
  use alienfile;
- 
+
  plugin 'Probe::CommandLine' => (
    command => 'gzip',
  );
@@ -229,23 +229,23 @@ Use L<Test::Alien>.  It has extensive documentation, and integrates nicely with 
 If you have a diff file you can use patch:
 
  use alienfile;
- 
+
  probe sub { 'share' }; # replace with appropriate probe
- 
+
  share {
    ...
    patch [ '%{patch} -p1 < %{.install.patch}/mypatch.diff' ];
    build [ ... ] ;
  }
- 
+
  ...
 
 You can also patch using Perl if that is easier:
 
  use alienfile;
- 
+
  probe sub { 'share' };
- 
+
  share {
    ...
    patch sub {
@@ -291,7 +291,7 @@ you will get an error, allowing you to install the library, and retry the alien 
 also set the environment variable on just some aliens.
 
  % export ALIEN_INSTALL_TYPE=system  # for everyone
- 
+
  % env ALIEN_INSTALL_TYPE=system cpanm -v Alien::libfoo
 
 =head2 For testing I would like to test both system and share installs!
@@ -330,7 +330,7 @@ L<https://groups.google.com/forum/#!forum/perl5-alien>
 
 =item Open a support ticket
 
-If you have an issue with L<Alie::Build> itself, then please open a support ticket on the project's GitHub issue 
+If you have an issue with L<Alie::Build> itself, then please open a support ticket on the project's GitHub issue
 tracker.
 
 L<https://github.com/plicease/Alien-Build/issues>

--- a/lib/Alien/Build/Manual/PluginAuthor.pod
+++ b/lib/Alien/Build/Manual/PluginAuthor.pod
@@ -7,20 +7,20 @@
 your plugin:
 
  package Alien::Build::Plugin::Build::MyPlugin;
- 
+
  use strict;
  use warnings;
  use Alien::Build::Plugin;
- 
+
  has arg1 => 'default_for arg1';
  has arg2 => sub { [ 'default', 'for', 'arg2' ] };
- 
+
  sub init
  {
    my($self, $meta) = @_;
    ...
  }
- 
+
  1;
 
 and then from L<alienfile>:
@@ -69,7 +69,7 @@ You can also modify hooks using C<before_hook>, C<around_hook> and C<after_hook>
  sub init
  {
    my($self, $meta) = @_;
-   
+
    $meta->before_hook(
      build => sub {
        my($build) = @_;
@@ -83,14 +83,14 @@ You can also modify hooks using C<before_hook>, C<around_hook> and C<after_hook>
        $build->log('this runs after the build');
      },
    );
-   
+
    $meta->around_hook(
      build => sub {
        my $orig = shift;
-       
+
        # around hooks are useful for setting environment variables
        local $ENV{CPPFLAGS} = '-I/foo/include';
-       
+
        $orig->(@_);
      },
    );
@@ -102,7 +102,7 @@ inline L<alienfile> in your test.
 
  use Test::V0;
  use Test::Alien::Build;
- 
+
  my $build = alienfile_ok q{
    use alienfile;
    plugin 'Build::MyPlugin' => (
@@ -111,11 +111,11 @@ inline L<alienfile> in your test.
    );
    ...
  };
- 
+
  # you can interrogate $build, it is an instance of L<Alien::Build>.
- 
+
  my $alien = alien_build_ok;
- 
+
  # you can interrogate $alien, it is an instance of L<Alien::Base>.
 
 =head1 HOOKS
@@ -127,7 +127,7 @@ inline L<alienfile> in your test.
    return 'system' if ...; # system install
    return 'share';         # otherwise
  });
- 
+
  $meta->register_hook( probe => [ $command ] );
 
 This hook should return the string C<system> if the operating
@@ -178,35 +178,35 @@ an archive (like tar, zip, etc), or as a directory of files (git clone,
 etc).  When the hook is called, the current working directory will be a
 new empty directory, so you can save the download to the current
 directory.  If you store a single file in the directory, L<Alien::Build>
-will assume that it is an archive, which will be processed by the 
+will assume that it is an archive, which will be processed by the
 extract hook below.  If you store multiple files, L<Alien::Build> will
 assume the current directory is the source root.  If no files are stored
 at all, an exception with an appropriate diagnostic will be thrown.
 
-B<Note>: If you register this hook, then the fetch, decode and prefer 
+B<Note>: If you register this hook, then the fetch, decode and prefer
 hooks will NOT be called.
 
 =head2 fetch hook
 
  package Alien::Build::Plugin::MyPlugin;
- 
+
  use strict;
  use warnings;
  use Alien::Build::Plugin;
  use Carp ();
- 
+
  has '+url' => sub { Carp::croak "url is required property" };
 
  sub init
  {
    my($self, $meta) = @_;
-   
+
    $meta->register_hook( fetch => sub {
      my($build, $url) = @_;
      ...
    }
  }
- 
+
  1;
 
 Used to fetch a resource.  The first time it will be called without an
@@ -225,7 +225,7 @@ with the following keys:
    content  => $content,
    version  => $version,  # optional, if known
  };
- 
+
  # content of file stored in the filesystem
  return {
    type     => 'file',
@@ -280,7 +280,7 @@ reference:
  sub init
  {
    my($self, $meta) = @_;
-   
+
    $meta->register_hook( decode => sub {
      my($build, $res) = @_;
      ...
@@ -300,7 +300,7 @@ hash references.
  sub init
  {
    my($self, $meta) = @_;
-   
+
    $meta->register_hook( prefer => sub {
      my($build, $res) = @_;
      return {
@@ -368,7 +368,7 @@ This is the same as C<build>, except it fires only on a FFI build.
 
  $meta->register_hook( register_hook => sub {
    my($build) = @_;
-   ... 
+   ...
  });
 
 This is the same as C<gather_system>, except it fires after a C<share>
@@ -378,7 +378,7 @@ install.
 
  $meta->register_hook( register_ffi => sub {
    my($build) = @_;
-   ... 
+   ...
  });
 
 This is the same as C<gatehr_share>, except it fires after a C<share> FFI

--- a/lib/Alien/Build/Plugin.pm
+++ b/lib/Alien/Build/Plugin.pm
@@ -15,14 +15,14 @@ our @CARP_NOT = qw( alienfile Alien::Build Alien::Build::Meta );
 Create your plugin:
 
  package Alien::Build::Plugin::Type::MyPlugin;
- 
+
  use Alien::Build::Plugin;
  use Carp ();
- 
+
  has prop1 => 'default value';
  has prop2 => sub { 'default value' };
  has prop3 => sub { Carp::croak 'prop3 is a required property' };
- 
+
  sub init
  {
    my($self, $meta) = @_;
@@ -30,7 +30,7 @@ Create your plugin:
    my $prop1 = $self->prop1;
    my $prop2 = $self->prop2;
    my $prop3 = $self->prop3;
-   
+
    $meta->register_hook(sub {
      build => [ '%{make}', '%{make} install' ],
    });
@@ -100,22 +100,22 @@ sub new
   my $class = shift;
   my %args = @_ == 1 ? ($class->meta->default => $_[0]) : @_;
   my $self = bless {}, $class;
-  
+
   my $prop = $self->meta->prop;
   foreach my $name (keys %$prop)
   {
-    $self->{$name} = defined $args{$name} 
-      ? delete $args{$name} 
+    $self->{$name} = defined $args{$name}
+      ? delete $args{$name}
       : ref($prop->{$name}) eq 'CODE'
         ? $prop->{$name}->()
         : $prop->{$name};
   }
-  
+
   foreach my $name (keys %args)
   {
     Carp::carp "$class has no $name property";
   }
-  
+
   $self;
 }
 
@@ -144,13 +144,13 @@ sub import
 
   my $caller = caller;
   { no strict 'refs'; @{ "${caller}::ISA" } = __PACKAGE__ }
-  
+
   my $meta = $caller->meta;
   my $has = sub {
     my($name, $default) = @_;
     $meta->add_property($name, $default);
   };
-  
+
   { no strict 'refs'; *{ "${caller}::has" } = $has }
 }
 
@@ -246,7 +246,7 @@ sub add_property
     $self->{$name} = $new if defined $new;
     $self->{$name};
   };
-  
+
   # add the accessor
   { no strict 'refs'; *{ $self->{class} . '::' . $name} = $accessor }
 

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -62,14 +62,14 @@ has msys_version   => undef;
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->apply_plugin('Build::MSYS',
     (defined $self->msys_version ? (msys_version => $self->msys_version) : ()),
   );
-  
+
   $meta->prop->{destdir} = 1;
   $meta->prop->{autoconf} = 1;
-  
+
   my $intr = $meta->interpolator;
 
   my $set_autoconf_prefix = sub {
@@ -112,11 +112,11 @@ sub init
       my $prefix = $build->install_prop->{autoconf_prefix};
       die "Prefix is not set.  Did you forget to run 'make alien_prefix'?"
         unless $prefix;
-      
+
       $intr->replace_helper(
         configure => sub {
           my $configure;
-          
+
           if($build->meta_prop->{out_of_source})
           {
             my $extract = $build->install_prop->{extract};
@@ -139,7 +139,7 @@ sub init
         my $real_prefix = Path::Tiny->new($build->install_prop->{prefix});
         my @pkgconf_dirs;
         push @pkgconf_dirs, Path::Tiny->new($ENV{DESTDIR})->child($prefix)->child("$_/pkgconfig") for qw(lib share);
-      
+
         # for any pkg-config style .pc files that are dropped, we need
         # to convert the MSYS /C/Foo style paths to C:/Foo
         for my $pkgconf_dir (@pkgconf_dirs) {
@@ -152,7 +152,7 @@ sub init
             }
         }
       }
-      
+
       $ret;
     },
   );
@@ -175,7 +175,7 @@ Some reasonable default flags will be provided.
       $configure;
     },
   );
-  
+
   $meta->default_hook(
     build => [
       '%{configure} --disable-shared',
@@ -183,7 +183,7 @@ Some reasonable default flags will be provided.
       '%{make} install',
     ]
   );
-  
+
   $self;
 }
 

--- a/lib/Alien/Build/Plugin/Build/CMake.pm
+++ b/lib/Alien/Build/Plugin/Build/CMake.pm
@@ -13,7 +13,7 @@ use Capture::Tiny qw( capture );
 =head1 SYNOPSIS
 
  use alienfile;
- 
+
  share {
    plugin 'Build::CMake';
    build [
@@ -92,7 +92,7 @@ sub cmake_generator
   if($^O eq 'MSWin32')
   {
     return 'MinGW Makefiles' if is_dmake();
-  
+
     {
       my($out, $err) = capture { system $Config{make}, '/?' };
       return 'NMake Makefiles' if $out =~ /NMAKE/;
@@ -114,9 +114,9 @@ sub cmake_generator
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->prop->{destdir} = $^O eq 'MSWin32' ? 0 : 1;
-  
+
   $meta->add_requires('configure' => 'Alien::Build::Plugin::Build::CMake' => '0.99');
   $meta->add_requires('share'     => 'Alien::cmake3' => '0.02');
 
@@ -150,7 +150,7 @@ sub init
   $meta->interpolator->add_helper('cmake_generator' => \&cmake_generator);
 
   my @args = (
-    -G => '%{cmake_generator}', 
+    -G => '%{cmake_generator}',
     '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true',
     '-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',
     '-DCMAKE_MAKE_PROGRAM:PATH=%{make}',

--- a/lib/Alien/Build/Plugin/Build/MSYS.pm
+++ b/lib/Alien/Build/Plugin/Build/MSYS.pm
@@ -36,16 +36,16 @@ has msys_version   => '0.07';
 sub init
 {
   my($self, $meta) = @_;
-  
+
   if($self->msys_version ne '0.07')
   {
     $meta->add_requires('configure' => 'Alien::Build::Plugin::Build::MSYS' => '0.84');
   }
-  
+
   if(_win_and_needs_msys($meta))
   {
     $meta->add_requires('share' => 'Alien::MSYS' => $self->msys_version);
-    
+
     $meta->around_hook(
       build => sub {
         my $orig = shift;
@@ -70,7 +70,7 @@ L<Alien::MSYS>.  This is almost certainly what you want, as most unix style make
 projects will not build with C<nmake> or C<dmake> typically used by Perl on Windows.
 
 =cut
- 
+
   if($^O eq 'MSWin32')
   {
     # Most likely if we are trying to build something unix-y and
@@ -81,7 +81,7 @@ projects will not build with C<nmake> or C<dmake> typically used by Perl on Wind
     );
 
   }
-  
+
   $self;
 }
 

--- a/lib/Alien/Build/Plugin/Build/Make.pm
+++ b/lib/Alien/Build/Plugin/Build/Make.pm
@@ -26,8 +26,8 @@ projects do not use.  This plugin will alter the L<alienfile> recipe to use a di
 case of C<gmake> / L<Alien::gmake>) automatically download and install an alienized version of that C<make> if it
 is not already installed.
 
-This plugin should NOT be used with other plugins that replace the C<make> helper, like 
-L<Alien::Build::Plugin::Build::CMake>, L<Alien::Build::Plugin::Build::Autoconf>, 
+This plugin should NOT be used with other plugins that replace the C<make> helper, like
+L<Alien::Build::Plugin::Build::CMake>, L<Alien::Build::Plugin::Build::Autoconf>,
 L<Alien::Build::Plugin::Build::MSYS>.  This plugin is intended instead for projects that use vanilla makefiles of
 a specific type.
 
@@ -77,23 +77,23 @@ sub init
   my($self, $meta) = @_;
 
   $meta->add_requires('configure', 'Alien::Build::Plugin::Build::Make', '0.99');
-  
+
   my $type = $self->make_type;
-  
+
   return unless defined $type;
-  
+
   $type = 'gmake' if $^O eq 'MSWin32' && $type eq 'umake';
-  
+
   if($type eq 'nmake')
   {
     $meta->interpolator->replace_helper( make => sub { 'nmake' } );
   }
-  
+
   elsif($type eq 'dmake')
   {
     $meta->interpolator->replace_helper( make => sub { 'dmake' } );
   }
-  
+
   elsif($type eq 'gmake')
   {
     my $found = 0;
@@ -112,12 +112,12 @@ sub init
       $meta->interpolator->replace_helper('make' => sub { require Alien::gmake; Alien::gmake->exe });
     }
   }
-  
+
   elsif($type eq 'umake')
   {
     # nothing
   }
-  
+
   else
   {
     Carp::croak("unknown make type = ", $self->make_type);

--- a/lib/Alien/Build/Plugin/Build/SearchDep.pm
+++ b/lib/Alien/Build/Plugin/Build/SearchDep.pm
@@ -48,15 +48,15 @@ has public_l => 0;
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->add_requires('configure' => 'Alien::Build::Plugin::Build::SearchDep' => '0.35');
   $meta->add_requires('share'     => 'Env::ShellWords' => 0.01);
-  
+
   if($self->public_I || $self->public_l)
   {
     $meta->add_requires('configure' => 'Alien::Build::Plugin::Build::SearchDep' => '0.53');
   }
-  
+
   my @aliens;
   if(ref($self->aliens) eq 'HASH')
   {
@@ -68,23 +68,23 @@ sub init
     @aliens = ref $self->aliens ? @{ $self->aliens } : ($self->aliens);
     $meta->add_requires('share' => $_ => 0) for @aliens;
   }
-  
+
   $meta->around_hook(
     build => sub {
       my($orig, $build) = @_;
-      
+
       local $ENV{CFLAGS}   = $ENV{CFLAGS};
       local $ENV{CXXFLAGS} = $ENV{CXXFLAGS};
       local $ENV{LDFLAGS}  = $ENV{LDFLAGS};
-      
+
       tie my @CFLAGS,   'Env::ShellWords', 'CFLAGS';
       tie my @CXXFLAGS, 'Env::ShellWords', 'CXXFLAGS';
       tie my @LDFLAGS,  'Env::ShellWords', 'LDFLAGS';
-      
+
       my $cflags  = $build->install_prop->{plugin_build_searchdep_cflags}  = [];
       my $ldflags = $build->install_prop->{plugin_build_searchdep_ldflags} = [];
       my $libs    = $build->install_prop->{plugin_build_searchdep_libs}    = [];
-      
+
       foreach my $other (@aliens)
       {
         my $other_cflags;
@@ -103,20 +103,20 @@ sub init
         unshift @$ldflags, grep /^-L/, shellwords($other_libs);
         unshift @$libs,    grep /^-l/, shellwords($other_libs);
       }
-      
+
       unshift @CFLAGS, @$cflags;
       unshift @CXXFLAGS, @$cflags;
       unshift @LDFLAGS, @$ldflags;
-      
+
       $orig->($build);
-      
+
     },
   );
-  
+
   $meta->after_hook(
     gather_share => sub {
       my($build) = @_;
-      
+
       $build->runtime_prop->{libs}        = '' unless defined $build->runtime_prop->{libs};
       $build->runtime_prop->{libs_static} = '' unless defined $build->runtime_prop->{libs_static};
 
@@ -125,7 +125,7 @@ sub init
         $build->runtime_prop->{$_} = join(' ', _space_escape(@{ $build->install_prop->{plugin_build_searchdep_libs} })) . ' ' . $build->runtime_prop->{$_}
           for qw( libs libs_static );
       }
-      
+
       $build->runtime_prop->{$_} = join(' ', _space_escape(@{ $build->install_prop->{plugin_build_searchdep_ldflags} })) . ' ' . $build->runtime_prop->{$_}
         for qw( libs libs_static );
 

--- a/lib/Alien/Build/Plugin/Core/Legacy.pm
+++ b/lib/Alien/Build/Plugin/Core/Legacy.pm
@@ -26,15 +26,15 @@ L<Alien::Build>, L<Alien::Base::ModuleBuild>
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->after_hook(
     $_ => sub {
       my($build) = @_;
-      
+
       $build->log("adding legacy hash to config");
-      
+
       my $runtime = $build->runtime_prop;
-      
+
       if($runtime->{cflags} && ! defined $runtime->{cflags_static})
       {
         $runtime->{cflags_static} = $runtime->{cflags};
@@ -44,7 +44,7 @@ sub init
       {
         $runtime->{libs_static} = $runtime->{libs};
       }
-      
+
       $runtime->{legacy}->{finished_installing} = 1;
       $runtime->{legacy}->{install_type}        = $runtime->{install_type};
       $runtime->{legacy}->{version}             = $runtime->{version};

--- a/lib/Alien/Build/Plugin/Core/Override.pm
+++ b/lib/Alien/Build/Plugin/Core/Override.pm
@@ -25,7 +25,7 @@ L<Alien::Build>, L<Alien::Base::ModuleBuild>
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->default_hook(
     override => sub {
       my($build) = @_;

--- a/lib/Alien/Build/Plugin/Core/Setup.pm
+++ b/lib/Alien/Build/Plugin/Core/Setup.pm
@@ -26,7 +26,7 @@ L<Alien::Build>, L<Alien::Base::ModuleBuild>
 
 sub init
 {
-  my($self, $meta) = @_;  
+  my($self, $meta) = @_;
   $meta->prop->{platform} ||= {};
   $self->_platform($meta->prop->{platform});
 }
@@ -34,7 +34,7 @@ sub init
 sub _platform
 {
   my(undef, $hash) = @_;
-  
+
   if($^O eq 'MSWin32' && $Config{ccname} eq 'cl')
   {
     $hash->{compiler_type} = 'microsoft';
@@ -43,7 +43,7 @@ sub _platform
   {
     $hash->{compiler_type} = 'unix';
   }
-  
+
   if($^O eq 'MSWin32')
   {
     $hash->{system_type} = 'windows-unknown';

--- a/lib/Alien/Build/Plugin/Decode/DirListing.pm
+++ b/lib/Alien/Build/Plugin/Decode/DirListing.pm
@@ -30,15 +30,15 @@ sub init
 
   $meta->add_requires('share' => 'File::Listing' => 0);
   $meta->add_requires('share' => 'URI' => 0);
-  
+
   $meta->register_hook( decode => sub {
     my(undef, $res) = @_;
-    
+
     die "do not know how to decode @{[ $res->{type} ]}"
       unless $res->{type} eq 'dir_listing';
-    
+
     my $base = URI->new($res->{base});
-    
+
     return {
       type => 'list',
       list => [

--- a/lib/Alien/Build/Plugin/Decode/DirListingFtpcopy.pm
+++ b/lib/Alien/Build/Plugin/Decode/DirListingFtpcopy.pm
@@ -35,7 +35,7 @@ sub init
 
   $meta->add_requires('share' => 'File::Listing::Ftpcopy' => 0);
   $meta->add_requires('share' => 'URI' => 0);
-  
+
   $meta->register_hook( decode => sub {
     my(undef, $res) = @_;
 
@@ -43,7 +43,7 @@ sub init
       unless $res->{type} eq 'dir_listing';
 
     my $base = URI->new($res->{base});
-    
+
     return {
       type => 'list',
       list => [

--- a/lib/Alien/Build/Plugin/Decode/HTML.pm
+++ b/lib/Alien/Build/Plugin/Decode/HTML.pm
@@ -30,17 +30,17 @@ sub init
   $meta->add_requires('share' => 'HTML::LinkExtor' => 0);
   $meta->add_requires('share' => 'URI' => 0);
   $meta->add_requires('share' => 'URI::Escape' => 0);
-  
+
   $meta->register_hook( decode => sub {
     my(undef, $res) = @_;
-    
+
     die "do not know how to decode @{[ $res->{type} ]}"
       unless $res->{type} eq 'html';
-    
+
     my $base = URI->new($res->{base});
-    
+
     my @list;
-    
+
     my $p = HTML::LinkExtor->new(sub {
       my($tag, %links) = @_;
       if($tag eq 'base' && $links{href})
@@ -60,9 +60,9 @@ sub init
         };
       }
     });
-    
+
     $p->parse($res->{content});
-    
+
     return {
       type => 'list',
       list => \@list,

--- a/lib/Alien/Build/Plugin/Download/Negotiate.pm
+++ b/lib/Alien/Build/Plugin/Download/Negotiate.pm
@@ -113,13 +113,13 @@ Returns the fetch plugin and any optional decoders that should be used.
 sub pick
 {
   my($self) = @_;
-  
+
   $self->scheme(
     $self->url !~ m!(ftps?|https?|file):!i
       ? 'file'
       : $self->url =~ m!^([a-z]+):!i
   ) unless defined $self->scheme;
-  
+
   if($self->scheme eq 'https' || ($self->scheme eq 'http' && $self->ssl))
   {
     if($self->bootstrap_ssl && ! eval { require Net::SSLeay; 1 })
@@ -161,7 +161,7 @@ sub pick
 sub init
 {
   my($self, $meta) = @_;
-  
+
   unless(defined $self->url)
   {
     if(defined $meta->prop->{start_url})
@@ -173,14 +173,14 @@ sub init
       Carp::croak "url is a required property unless you use the start_url directive";
     }
   }
-  
+
   $meta->add_requires('share' => 'Alien::Build::Plugin::Download::Negotiate' => '0.61')
     if $self->passive;
 
   $meta->prop->{plugin_download_negotiate_default_url} = $self->url;
 
   my($fetch, @decoders) = $self->pick;
-  
+
   $fetch = [ $fetch ] unless ref $fetch;
 
   foreach my $fetch (@$fetch)
@@ -191,14 +191,14 @@ sub init
     # this used to be the interface.  Using start_url is now preferred!
     push @args, url => $self->url if $fetch =~ /^Fetch::(HTTPTiny|LWP|Local|LocalDir|NetFTP)$/;
     push @args, passive => $self->passive if $fetch eq 'Fetch::NetFTP';
-  
+
     $meta->apply_plugin($fetch, @args);
   }
-  
+
   if($self->version)
   {
     $meta->apply_plugin($_) for @decoders;
-    $meta->apply_plugin('Prefer::SortVersions', 
+    $meta->apply_plugin('Prefer::SortVersions',
       (defined $self->filter ? (filter => $self->filter) : ()),
       version => $self->version,
     );

--- a/lib/Alien/Build/Plugin/Extract.pod
+++ b/lib/Alien/Build/Plugin/Extract.pod
@@ -12,8 +12,8 @@
 =head1 DESCRIPTION
 
 Extract plugins extract packages that have been downloaded from the internet.
-Unless you are doing something unusual you will likely want to use the 
-L<Alien::Build::Plugin::Extract::Negotiate> plugin to select the best 
+Unless you are doing something unusual you will likely want to use the
+L<Alien::Build::Plugin::Extract::Negotiate> plugin to select the best
 Extract plugin available.
 
 =over 4

--- a/lib/Alien/Build/Plugin/Extract/ArchiveTar.pm
+++ b/lib/Alien/Build/Plugin/Extract/ArchiveTar.pm
@@ -52,9 +52,9 @@ given format.
 sub handles
 {
   my(undef, $ext) = @_;
-  
+
   return 1 if $ext =~ /^(tar|tar.gz|tar.bz2|tbz|taz)$/;
-  
+
   return;
 }
 
@@ -69,7 +69,7 @@ Returns true if the plugin has what it needs right now to extract from the given
 sub available
 {
   my(undef, $ext) = @_;
-  
+
   if($ext eq 'tar.gz')
   {
     return !! eval { require Archive::Tar; Archive::Tar->has_zlib_support };
@@ -87,7 +87,7 @@ sub available
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->add_requires('share' => 'Archive::Tar' => 0);
   if($self->format eq 'tar.gz' || $self->format eq 'tgz')
   {
@@ -98,7 +98,7 @@ sub init
     $meta->add_requires('share' => 'IO::Uncompress::Bunzip2' => 0);
     $meta->add_requires('share' => 'IO::Compress::Bzip2' => 0);
   }
-  
+
   $meta->register_hook(
     extract => sub {
       my($build, $src) = @_;

--- a/lib/Alien/Build/Plugin/Extract/ArchiveZip.pm
+++ b/lib/Alien/Build/Plugin/Extract/ArchiveZip.pm
@@ -45,9 +45,9 @@ given format.
 sub handles
 {
   my($class, $ext) = @_;
-  
+
   return 1 if $ext eq 'zip';
-  
+
   return;
 }
 
@@ -62,16 +62,16 @@ Returns true if the plugin has what it needs right now to extract from the given
 sub available
 {
   my(undef, $ext) = @_;
-  
+
   !! ( $ext eq 'zip' && eval { require Archive::Zip; 1} );
 }
 
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->add_requires('share' => 'Archive::Zip' => 0);
-  
+
   $meta->register_hook(
     extract => sub {
       my($build, $src) = @_;

--- a/lib/Alien/Build/Plugin/Extract/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Extract/CommandLine.pm
@@ -156,7 +156,7 @@ sub _dcon
     $self->xz_cmd(_which('xz')) unless defined $self->xz_cmd;
     $cmd = $self->xz_cmd unless $self->_tar_can('tar.xz');
   }
-  
+
   if($cmd && $src =~ /\.(gz|bz2|xz|Z)$/)
   {
     $name = $src;
@@ -167,7 +167,7 @@ sub _dcon
     $name = $src;
     $name =~ s/\.(tgz|tbz|txz|taz)$/.tar/;
   }
-  
+
   ($name,$cmd);
 }
 
@@ -186,7 +186,7 @@ given format.
 sub handles
 {
   my($class, $ext) = @_;
-  
+
   my $self = ref $class
   ? $class
   : __PACKAGE__->new;
@@ -200,14 +200,14 @@ sub handles
   return 1 if $ext eq 'tar.Z' && $self->_tar_can('tar.Z');
   return 1 if $ext eq 'tar.bz2' && $self->_tar_can('tar.bz2');
   return 1 if $ext eq 'tar.xz' && $self->_tar_can('tar.xz');
-  
+
   return if $ext =~ s/\.(gz|Z)$// && (!$self->gzip_cmd);
   return if $ext =~ s/\.bz2$//    && (!$self->bzip2_cmd);
   return if $ext =~ s/\.xz$//     && (!$self->xz_cmd);
-  
+
   return 1 if $ext eq 'tar' && $self->tar_cmd;
   return 1 if $ext eq 'zip' && $self->unzip_cmd;
-  
+
   return;
 }
 
@@ -225,13 +225,13 @@ sub available
   my(undef, $ext) = @_;
 
   # this is actually the same as handles
-  __PACKAGE__->handles($ext);  
+  __PACKAGE__->handles($ext);
 }
 
 sub init
 {
   my($self, $meta) = @_;
-  
+
   if($self->format eq 'tar.xz' && !$self->handles('tar.xz'))
   {
     $meta->add_requires('share' => 'Alien::xz' => '0.06');
@@ -244,13 +244,13 @@ sub init
   {
     $meta->add_requires('share' => 'Alien::gzip' => '0.03');
   }
-  
+
   $meta->register_hook(
     extract => sub {
       my($build, $src) = @_;
-      
+
       my($dcon_name, $dcon_cmd) = _dcon($self, $src);
-      
+
       if($dcon_name)
       {
         unless($dcon_cmd)
@@ -276,7 +276,7 @@ sub init
         }
         $src = $dcon_name;
       }
-      
+
       if($src =~ /\.zip$/i)
       {
         $self->_run($build, $self->unzip_cmd, $src);
@@ -302,7 +302,7 @@ sub _tar_can
   my $tar = $self->tar_cmd;
 
   return 1 if $ext eq 'tar';
-  
+
   unless(%tars)
   {
     my $name = '';
@@ -318,7 +318,7 @@ sub _tar_can
         $tars{$name} .= $_;
       }
     }
-    
+
     foreach my $key (keys %tars)
     {
       $tars{$key} = unpack "u", $tars{$key};
@@ -330,7 +330,7 @@ sub _tar_can
   return 0 unless $tars{$name};
 
   local $CWD = tempdir( CLEANUP => 1 );
-  
+
   my $cleanup = sub {
     my $save = $CWD;
     unlink $name;
@@ -338,23 +338,23 @@ sub _tar_can
     $CWD = '..';
     rmdir $save;
   };
-  
+
   Path::Tiny->new($name)->spew_raw($tars{$name});
 
   my(undef, $exit) = capture_merged {
     system($self->tar_cmd, 'xf', $name);
     $?;
   };
-  
+
   if($exit)
   {
     $cleanup->();
     return 0;
   }
-  
+
   my $content = eval { Path::Tiny->new('xx.txt')->slurp };
   $cleanup->();
-  
+
   return defined $content && $content eq "xx\n";
 }
 

--- a/lib/Alien/Build/Plugin/Extract/Directory.pm
+++ b/lib/Alien/Build/Plugin/Extract/Directory.pm
@@ -69,11 +69,11 @@ sub available
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->register_hook(
     extract => sub {
       my($build, $src) = @_;
-      
+
       die "not a directory: $src" unless -d $src;
 
       if($build->meta_prop->{out_of_source})

--- a/lib/Alien/Build/Plugin/Extract/Negotiate.pm
+++ b/lib/Alien/Build/Plugin/Extract/Negotiate.pm
@@ -20,7 +20,7 @@ use Alien::Build::Plugin::Extract::Directory;
 
 =head1 DESCRIPTION
 
-This is a negotiator plugin for extracting packages downloaded from the internet. 
+This is a negotiator plugin for extracting packages downloaded from the internet.
 This plugin picks the best Extract plugin to do the actual work.  Which plugins are
 picked depend on the properties you specify, your platform and environment.  It is
 usually preferable to use a negotiator plugin rather than using a specific Extract
@@ -40,12 +40,12 @@ has '+format' => 'tar';
 sub init
 {
   my($self, $meta) = @_;
-  
+
   my $format = $self->format;
   $format = 'tar.gz'  if $format eq 'tgz';
   $format = 'tar.bz2' if $format eq 'tbz';
   $format = 'tar.xz'  if $format eq 'txz';
-  
+
   my $plugin = $self->pick($format);
   $meta->apply_plugin($plugin, format => $format);
   $self;
@@ -64,7 +64,7 @@ Returns the name of the best plugin for the given format.
 sub pick
 {
   my(undef, $format) = @_;
-  
+
   if($format =~ /^tar(\.(gz|bz2))?$/)
   {
     if(Alien::Build::Plugin::Extract::ArchiveTar->available($format))
@@ -83,13 +83,13 @@ sub pick
     {
       return 'Extract::ArchiveZip';
     }
-    
+
     # if we don't have Archive::Zip, check if we have the unzip command
     elsif(Alien::Build::Plugin::Extract::CommandLine->available($format))
     {
       return 'Extract::CommandLine';
     }
-    
+
     # okay fine.  I will try to install Archive::Zip :(
     # if this becomes a problem in the future we can
     # create Alien::unzip and fallback on CommandLine instead.

--- a/lib/Alien/Build/Plugin/Fetch/CurlCommand.pm
+++ b/lib/Alien/Build/Plugin/Fetch/CurlCommand.pm
@@ -16,7 +16,7 @@ use File::chdir;
 =head1 SYNOPSIS
 
  use alienfile;
- 
+
  share {
    start_url 'https://www.openssl.org/source/';
    plugin 'Fetch::CurlCommand';
@@ -61,11 +61,11 @@ sub init
       $url ||= $meta->prop->{start_url};
 
       my($scheme) = $url =~ /^([a-z0-9]+):/i;
-      
+
       if($scheme =~ /^https?$/)
       {
         local $CWD = tempdir( CLEANUP => 1 );
-      
+
         path('writeout')->spew(
           join("\\n",
             "ab-filename     :%{filename_effective}",
@@ -73,17 +73,17 @@ sub init
             "ab-url          :%{url_effective}",
           ),
         );
-      
+
         my @command = (
           $self->curl_command,
           '-L', '-f', -o => 'content',
           -w => '@writeout',
         );
-      
+
         push @command, -D => 'head' if $self->_see_headers;
-      
+
         push @command, $url;
-      
+
         my($stdout, $stderr) = $self->_execute($build, @command);
 
         my %h = map { my($k,$v) = m/^ab-(.*?)\s*:(.*)$/; $k => $v } split /\n/, $stdout;
@@ -96,7 +96,7 @@ sub init
         {
           $h{filename} = 'index.html';
         }
-        
+
         rename 'content', $h{filename};
 
         if(-e 'head')
@@ -104,7 +104,7 @@ sub init
           $build->log(" ~ $_ => $h{$_}") for sort keys %h;
           $build->log(" header: $_") for path('headers')->lines;
         }
-      
+
         my($type) = split ';', $h{content_type};
 
         if($type eq 'text/html')
@@ -157,7 +157,7 @@ sub init
 #            };
 #          }
 #        }
-#        
+#
 #        {
 #          my($stdout, $stderr) = eval { $self->_execute($build, $self->curl_command, -l => "$url/") };
 #          if($@ eq '')
@@ -180,11 +180,11 @@ sub init
       {
         die "scheme $scheme is not supported by the Fetch::CurlCommand plugin";
       }
-      
+
     },
   ) if $self->curl_command;
-  
-  $self;  
+
+  $self;
 }
 
 sub _execute

--- a/lib/Alien/Build/Plugin/Fetch/HTTPTiny.pm
+++ b/lib/Alien/Build/Plugin/Fetch/HTTPTiny.pm
@@ -64,7 +64,7 @@ sub init
     $meta->add_requires('share' => 'IO::Socket::SSL' => '1.56' );
     $meta->add_requires('share' => 'Net::SSLeay'     => '1.49' );
   }
-  
+
   $meta->register_hook( fetch => sub {
     my($build, $url) = @_;
     $url ||= $self->url;
@@ -76,12 +76,12 @@ sub init
     {
       my $status = $res->{status} || '---';
       my $reason = $res->{reason} || 'unknown';
-      
+
       $build->log("$status $reason fetching $url");
       if($status == 599)
       {
         $build->log("exception: $_") for split /\n/, $res->{content};
-        
+
         my($can_ssl, $why_ssl) = HTTP::Tiny->can_ssl;
         if(! $can_ssl)
         {
@@ -97,7 +97,7 @@ sub init
           }
         }
       }
-      
+
       die "error fetching $url: $status $reason";
     }
 
@@ -116,7 +116,7 @@ sub init
         $filename = $1;
       }
     }
-    
+
     if($type eq 'text/html')
     {
       return {
@@ -133,7 +133,7 @@ sub init
         content  => $res->{content},
       };
     }
-    
+
   });
 
   $self;

--- a/lib/Alien/Build/Plugin/Fetch/LWP.pm
+++ b/lib/Alien/Build/Plugin/Fetch/LWP.pm
@@ -52,7 +52,7 @@ sub init
   my($self, $meta) = @_;
 
   $meta->add_requires('share' => 'LWP::UserAgent' => 0 );
-  
+
   $meta->prop->{start_url} ||= $self->url;
   $self->url($meta->prop->{start_url});
   $self->url || Carp::croak('url is a required property');
@@ -102,7 +102,7 @@ sub init
         content  => $res->content,
       };
     }
-    
+
   });
 
   $self;

--- a/lib/Alien/Build/Plugin/Fetch/Local.pm
+++ b/lib/Alien/Build/Plugin/Fetch/Local.pm
@@ -57,7 +57,7 @@ has ssl => 0;
 sub init
 {
   my($self, $meta) = @_;
-    
+
   $meta->prop->{start_url} ||= $self->url;
   $self->url($meta->prop->{start_url} || 'patch');
 
@@ -80,12 +80,12 @@ sub init
     }
     $self->root($root);
   }
-  
+
   $meta->register_hook( fetch => sub {
     my(undef, $path) = @_;
-    
+
     $path ||= $self->url;
-    
+
     if($path =~ /^file:/)
     {
       my $root = URI::file->new($self->root);
@@ -93,15 +93,15 @@ sub init
       $path = URI::Escape::uri_unescape($url->path);
       $path =~ s{^/([a-z]:)}{$1}i if $^O eq 'MSWin32';
     }
-    
+
     $path = Path::Tiny->new($path)->absolute($self->root);
-    
+
     if(-d $path)
     {
       return {
         type => 'list',
         list => [
-          map { { filename => $_->basename, url => $_->stringify } } 
+          map { { filename => $_->basename, url => $_->stringify } }
           sort { $a->basename cmp $b->basename } $path->children,
         ],
       };
@@ -119,8 +119,8 @@ sub init
     {
       die "no such file or directory $path";
     }
-    
-    
+
+
   });
 }
 

--- a/lib/Alien/Build/Plugin/Fetch/LocalDir.pm
+++ b/lib/Alien/Build/Plugin/Fetch/LocalDir.pm
@@ -48,9 +48,9 @@ has ssl => 0;
 sub init
 {
   my($self, $meta) = @_;
-  
+
   my $url = $meta->prop->{start_url} || 'patch';
-  
+
   $meta->add_requires('configure' => 'Alien::Build::Plugin::Fetch::LocalDir' => '0.72' );
 
   if($url =~ /^file:/)
@@ -71,13 +71,13 @@ sub init
     }
     $self->root($root);
   }
-  
+
   $meta->register_hook(
     fetch => sub {
       my($build, $path) = @_;
-      
+
       $path ||= $url;
-      
+
       if($path =~ /^file:/)
       {
         my $root = URI::file->new($self->root);
@@ -85,9 +85,9 @@ sub init
         $path = $url->path;
         $path =~ s{^/([a-z]:)}{$1}i if $^O eq 'MSWin32';
       }
-      
+
       $path = Path::Tiny->new($path)->absolute($self->root);
-      
+
       if(-d $path)
       {
         return {

--- a/lib/Alien/Build/Plugin/Fetch/NetFTP.pm
+++ b/lib/Alien/Build/Plugin/Fetch/NetFTP.pm
@@ -70,12 +70,12 @@ sub init
   $meta->register_hook( fetch => sub {
     my($build, $url) = @_;
     $url ||= $self->url;
-    
+
     $url = URI->new($url);
 
     die "Fetch::NetFTP does not support @{[ $url->scheme ]}"
       unless $url->scheme eq 'ftp';
-    
+
     $build->log("trying passive mode FTP first") if $self->passive;
     my $ftp = _ftp_connect($url, $self->passive);
 
@@ -86,27 +86,27 @@ sub init
       my(@parts) = split '/', $path;
       my $filename = pop @parts;
       my $dir      = join '/', @parts;
-      
+
       my $path = eval {
         $ftp->cwd($dir) or die;
         my $tdir = File::Temp::tempdir( CLEANUP => 1);
         my $path = path("$tdir/$filename")->stringify;
-        
+
         unless(eval { $ftp->get($filename, $path) }) # NAT problem? try to use passive mode
         {
           $ftp->quit;
-          
+
           $build->log("switching to @{[ $self->passive ? 'active' : 'passive' ]} mode");
           $ftp = _ftp_connect($url, !$self->passive);
-          
+
           $ftp->cwd($dir) or die;
-          
+
           $ftp->get($filename, $path) or die;
         }
-        
+
         $path;
       };
-      
+
       if(defined $path)
       {
         return {
@@ -115,33 +115,33 @@ sub init
           path     => $path,
         };
       }
-      
+
       $path .= "/";
     }
-    
+
     $ftp->quit;
     $ftp = _ftp_connect($url, $self->passive);
     $ftp->cwd($path) or die "unable to fetch $url as either a directory or file";
-    
+
     my $list = eval { $ftp->ls };
     unless(defined $list) # NAT problem? try to use passive mode
     {
       $ftp->quit;
-      
+
       $build->log("switching to @{[ $self->passive ? 'active' : 'passive' ]} mode");
       $ftp = _ftp_connect($url, !$self->passive);
-      
+
       $ftp->cwd($path) or die "unable to fetch $url as either a directory or file";
-      
+
       $list = $ftp->ls;
-      
+
       die "cannot list directory $path on $url" unless defined $list;
     }
-    
+
     die "no files found at $url" unless @$list;
 
     $path .= '/' unless $path =~ /\/$/;
-    
+
     return {
       type => 'list',
       list => [
@@ -157,7 +157,7 @@ sub init
         } sort @$list,
       ],
     };
-    
+
   });
 
   $self;
@@ -170,12 +170,12 @@ sub _ftp_connect {
   my $ftp = Net::FTP->new(
     $url->host, Port =>$url->port, Passive =>$is_passive,
   ) or die "error fetching $url: $@";
-  
+
   $ftp->login($url->user, $url->password)
     or die "error on login $url: @{[ $ftp->message ]}";
-  
+
   $ftp->binary;
-  
+
   $ftp;
 }
 

--- a/lib/Alien/Build/Plugin/Fetch/Wget.pm
+++ b/lib/Alien/Build/Plugin/Fetch/Wget.pm
@@ -15,7 +15,7 @@ use File::chdir;
 =head1 SYNOPSIS
 
  use alienfile;
- 
+
  share {
    start_url 'https://www.openssl.org/source/';
    plugin 'Fetch::Wget';
@@ -50,7 +50,7 @@ has ssl => 0;
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->add_requires('configure', 'Alien::Build::Plugin::Fetch::Wget' => '1.19');
 
   $meta->register_hook(
@@ -59,11 +59,11 @@ sub init
       $url ||= $meta->prop->{start_url};
 
       my($scheme) = $url =~ /^([a-z0-9]+):/i;
-      
+
       if($scheme eq 'http' || $scheme eq 'https')
       {
         local $CWD = tempdir( CLEANUP => 1 );
-        
+
         my($stdout, $stderr) = $self->_execute(
           $build,
           $self->wget_command,

--- a/lib/Alien/Build/Plugin/Gather/IsolateDynamic.pm
+++ b/lib/Alien/Build/Plugin/Gather/IsolateDynamic.pm
@@ -22,7 +22,7 @@ their own C<dynamic> directory.  This allows them to be used by FFI modules, but
 by XS modules.
 
 This plugin provides the equivalent functionality of the C<alien_isolate_dynamic> attribute
-from L<Alien::Base::ModuleBuild>.  
+from L<Alien::Base::ModuleBuild>.
 
 =cut
 
@@ -30,9 +30,9 @@ sub init
 {
   my($self, $meta) = @_;
 
-  # plugin was introduced in 0.42, but had a bug which was fixed in 0.48  
+  # plugin was introduced in 0.42, but had a bug which was fixed in 0.48
   $meta->add_requires('share' => 'Alien::Build::Plugin::Gather::IsolateDynamic' => '0.48' );
-  
+
   $meta->after_hook(
     gather_share => sub {
       my($build) = @_;

--- a/lib/Alien/Build/Plugin/PkgConfig/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/CommandLine.pm
@@ -99,13 +99,13 @@ sub available
 sub init
 {
   my($self, $meta) = @_;
-  
+
   my $pkgconf = $self->bin_name;
 
   my($pkg_name, @alt_names) = (ref $self->pkg_name) ? (@{ $self->pkg_name }) : ($self->pkg_name);
-  
+
   my @probe = map { [$pkgconf, '--exists', $_] } ($pkg_name, @alt_names);
-  
+
   if(defined $self->minimum_version)
   {
     push @probe, [ $pkgconf, '--atleast-version=' . $self->minimum_version, $pkg_name ];
@@ -115,13 +115,13 @@ sub init
     my($build) = @_;
     $build->runtime_prop->{legacy}->{name} ||= $pkg_name;
   };
-  
+
   $meta->register_hook(
     probe => \@probe
   );
 
   my @gather = map { [ $pkgconf, '--exists', $_] } ($pkg_name, @alt_names);
-  
+
   foreach my $prop_name (qw( cflags libs version ))
   {
     my $flag = $prop_name eq 'version' ? '--modversion' : "--$prop_name";
@@ -150,7 +150,7 @@ sub init
       }
     }
   }
-  
+
   $meta->register_hook(gather_system => [@gather]);
 
   if($meta->prop->{platform}->{system_type} eq 'windows-mingw')
@@ -172,7 +172,7 @@ sub init
       }
     },
   ) for qw( gather_system gather_share );
-  
+
   $self;
 }
 

--- a/lib/Alien/Build/Plugin/PkgConfig/LibPkgConf.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/LibPkgConf.pm
@@ -77,20 +77,20 @@ sub init
   {
     # Also update in Neotiate.pm
     $meta->add_requires('configure' => 'PkgConfig::LibPkgConf::Client' => _min_version);
-  
+
     if(defined $self->minimum_version)
     {
       $meta->add_requires('configure' => 'PkgConfig::LibPkgConf::Util' => _min_version);
     }
   }
-  
+
   my($pkg_name, @alt_names) = (ref $self->pkg_name) ? (@{ $self->pkg_name }) : ($self->pkg_name);
 
   $meta->register_hook(
     probe => sub {
       my($build) = @_;
       $build->runtime_prop->{legacy}->{name} ||= $pkg_name;
-    
+
       require PkgConfig::LibPkgConf::Client;
       my $client = PkgConfig::LibPkgConf::Client->new;
       my $pkg = $client->find($pkg_name);
@@ -103,29 +103,29 @@ sub init
           die "package $pkg_name is not recent enough";
         }
       }
-      
+
       foreach my $alt (@alt_names)
       {
         my $pkg = $client->find($alt);
         die "package $alt not found" unless $pkg;
       }
-      
+
       'system';
     },
   );
-  
+
   $meta->register_hook(
     $_ => sub {
       my($build) = @_;
       require PkgConfig::LibPkgConf::Client;
       my $client = PkgConfig::LibPkgConf::Client->new;
-      
+
       foreach my $name ($pkg_name, @alt_names)
       {
         my $pkg = $client->find($name);
         die "reload of package $name failed" unless defined $pkg;
 
-        my %prop;      
+        my %prop;
         $prop{version}        = $pkg->version;
         $prop{cflags}         = $pkg->cflags;
         $prop{libs}           = $pkg->libs;
@@ -133,7 +133,7 @@ sub init
         $prop{libs_static}    = $pkg->libs_static;
         $build->runtime_prop->{alt}->{$name} = \%prop;
       }
-      
+
       foreach my $key (keys %{ $build->runtime_prop->{alt}->{$pkg_name} })
       {
         $build->runtime_prop->{$key} = $build->runtime_prop->{alt}->{$pkg_name}->{$key};
@@ -145,7 +145,7 @@ sub init
       }
     },
   ) for qw( gather_system gather_share );
-  
+
   $self;
 }
 

--- a/lib/Alien/Build/Plugin/PkgConfig/MakeStatic.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/MakeStatic.pm
@@ -11,7 +11,7 @@ use Path::Tiny ();
 =head1 SYNOPSIS
 
  use alienfile;
- 
+
  plugin 'PkgConfig::MakeStatic' => (
    path => 'lib/pkgconfig/foo.pc',
  );
@@ -35,12 +35,12 @@ has path => undef;
 sub _convert
 {
   my($self, $build, $path) = @_;
-  
+
   die "unable to read $path" unless -r $path;
   die "unable to write $path" unless -w $path;
-  
+
   $build->log("converting $path to static");
-  
+
   my %h = map {
     my($key, $value) = $_ =~ /^(.*?):(.*?)$/;
     $value =~ s{^\s+}{};
@@ -50,15 +50,15 @@ sub _convert
 
   $h{Cflags} = '' unless defined $h{Cflags};
   $h{Libs}   = '' unless defined $h{Libs};
-  
+
   $h{Cflags} .= ' ' . $h{"Cflags.private"} if defined $h{"Cflags.private"};
   $h{Libs}   .= ' ' . $h{"Libs.private"} if defined $h{"Libs.private"};
-  
+
   $h{"Cflags.private"} = '';
   $h{"Libs.private"}  = '';
-  
+
   $path->edit_lines(sub {
-  
+
     if(/^(.*?):/)
     {
       my $key = $1;
@@ -68,7 +68,7 @@ sub _convert
         delete $h{$key};
       }
     }
-  
+
   });
 
   $path->append("$_: $h{$_}\n") foreach keys %h;
@@ -77,7 +77,7 @@ sub _convert
 sub _recurse
 {
   my($self, $build, $dir) = @_;
-  
+
   foreach my $child ($dir->children)
   {
     if(-d $child)
@@ -100,7 +100,7 @@ sub init
   $meta->before_hook(
     gather_share => sub {
       my($build) = @_;
-    
+
       if($self->path)
       {
         $self->_convert($build, Path::Tiny->new($self->path)->absolute);
@@ -109,7 +109,7 @@ sub init
       {
         $self->_recurse($build, Path::Tiny->new(".")->absolute);
       }
-    
+
     },
   );
 }

--- a/lib/Alien/Build/Plugin/PkgConfig/Negotiate.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/Negotiate.pm
@@ -59,12 +59,12 @@ sub pick
   my($class) = @_;
 
   return $ENV{ALIEN_BUILD_PKG_CONFIG} if $ENV{ALIEN_BUILD_PKG_CONFIG};
-  
+
   if(Alien::Build::Plugin::PkgConfig::LibPkgConf->available)
   {
     return 'PkgConfig::LibPkgConf';
   }
-  
+
   if(Alien::Build::Plugin::PkgConfig::CommandLine->available)
   {
     unless(_perl_config('osname') eq 'solaris' && _perl_config('ptrsize') == 8)
@@ -72,7 +72,7 @@ sub pick
       return 'PkgConfig::CommandLine';
     }
   }
-  
+
   if(Alien::Build::Plugin::PkgConfig::PP->available)
   {
     return 'PkgConfig::PP';
@@ -94,17 +94,17 @@ sub init
 
   my $plugin = $self->pick;
   Alien::Build->log("Using PkgConfig plugin: $plugin");
-  
+
   if(ref($self->pkg_name) eq 'ARRAY')
   {
     $meta->add_requires('configure', 'Alien::Build::Plugin::PkgConfig::Negotiate' => '0.79');
   }
-  
+
   my @args;
   push @args, pkg_name         => $self->pkg_name;
   push @args, register_prereqs => 0;
   push @args, minimum_version  => $self->minimum_version if defined $self->minimum_version;
-  
+
   $meta->apply_plugin($plugin, @args);
 
   $self;

--- a/lib/Alien/Build/Plugin/PkgConfig/PP.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/PP.pm
@@ -76,12 +76,12 @@ sub _cleanup
 sub init
 {
   my($self, $meta) = @_;
-  
+
   if($self->register_prereqs)
   {
     $meta->add_requires('configure' => 'PkgConfig' => _min_version);
   }
-  
+
   my($pkg_name, @alt_names) = (ref $self->pkg_name) ? (@{ $self->pkg_name }) : ($self->pkg_name);
 
   $meta->register_hook(
@@ -101,13 +101,13 @@ sub init
           die "package @{[ $pkg_name ]} is not recent enough";
         }
       }
-      
+
       foreach my $alt (@alt_names)
       {
         my $pkg = PkgConfig->find($alt);
         die "package $alt not found" if $pkg->errmsg;
       }
-      
+
       'system';
     },
   );
@@ -148,7 +148,7 @@ sub init
       delete $build->runtime_prop->{alt};
     }
   };
-  
+
   $meta->register_hook(
     gather_system => $gather,
   );
@@ -156,7 +156,7 @@ sub init
   $meta->register_hook(
     gather_share => $gather,
   );
-  
+
   $self;
 }
 

--- a/lib/Alien/Build/Plugin/Prefer.pod
+++ b/lib/Alien/Build/Plugin/Prefer.pod
@@ -12,7 +12,7 @@
 
 =head1 DESCRIPTION
 
-Prefer plugins sort 
+Prefer plugins sort
 
 Decode plugins decode HTML and FTP file listings.  Normally you
 will want to use the L<Alien::Build::Plugin::Download::Negotiate>

--- a/lib/Alien/Build/Plugin/Prefer/BadVersion.pm
+++ b/lib/Alien/Build/Plugin/Prefer/BadVersion.pm
@@ -84,9 +84,9 @@ sub init
   my($self, $meta) = @_;
 
   $meta->add_requires('configure', __PACKAGE__, '1.05');
-  
+
   my $filter;
-  
+
   if(ref($self->filter) eq '')
   {
     my $string = $self->filter;
@@ -112,13 +112,13 @@ sub init
   {
     Carp::croak("unknown filter type for Prefer::BadVersion");
   }
-  
+
   $meta->around_hook(
     prefer => sub {
       my($orig, $build, @therest) = @_;
       my $res1 = $orig->($build, @therest);
       return $res1 unless $res1->{type} eq 'list';
-      
+
       return {
         type => 'list',
         list => [

--- a/lib/Alien/Build/Plugin/Prefer/SortVersions.pm
+++ b/lib/Alien/Build/Plugin/Prefer/SortVersions.pm
@@ -10,7 +10,7 @@ use Alien::Build::Plugin;
 =head1 SYNOPSIS
 
  use alienfile;
- 
+
  plugin 'Prefer::SortVersions';
 
 =head1 DESCRIPTION
@@ -57,17 +57,17 @@ has '+version' => qr/([0-9](?:[0-9\.]*[0-9])?)/;
 sub init
 {
   my($self, $meta) = @_;
-  
+
   $meta->add_requires('share' => 'Sort::Versions' => 0);
-  
+
   $meta->register_hook( prefer => sub {
     my(undef, $res) = @_;
-    
+
     my $cmp = sub {
       my($A,$B) = map { $_ =~ $self->version } @_;
       Sort::Versions::versioncmp($B,$A);
     };
-    
+
     my @list = sort { $cmp->($a->{filename}, $b->{filename}) }
                map {
                  ($_->{version}) = $_->{filename} =~ $self->version;
@@ -75,7 +75,7 @@ sub init
                grep { $_->{filename} =~ $self->version }
                grep { defined $self->filter ? $_->{filename} =~ $self->filter : 1 }
                @{ $res->{list} };
-    
+
     return {
       type => 'list',
       list => \@list,

--- a/lib/Alien/Build/Plugin/Probe.pod
+++ b/lib/Alien/Build/Plugin/Probe.pod
@@ -26,7 +26,7 @@ look for tools in the path:
 
 Probe plugins try to find existing libraries and tools
 I<already> installed on the system.  If found they can
-be used instead of downloading the source from the 
+be used instead of downloading the source from the
 internet and building.
 
 =over 4

--- a/lib/Alien/Build/Plugin/Probe/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Probe/CommandLine.pm
@@ -44,7 +44,7 @@ has 'args'       => [];
 
 =head2 secondary
 
-If you are using another probe plugin (such as L<Alien::Build::Plugin::Probe::CBuilder> or 
+If you are using another probe plugin (such as L<Alien::Build::Plugin::Probe::CBuilder> or
 L<Alien::Build::Plugin::PkgConfig::Negotiate>) to detect the existence of a library, but
 also need a program to exist, then you should set secondary to a true value.  For example
 when you need both:
@@ -106,7 +106,7 @@ has 'version_stderr' => undef;
 sub init
 {
   my($self, $meta) = @_;
-  
+
   my $check = sub {
     my($build) = @_;
 
@@ -142,7 +142,7 @@ sub init
     $build->runtime_prop->{command} = $self->command;
     'system';
   };
-  
+
   if($self->secondary)
   {
     $meta->around_hook(

--- a/lib/Alien/Build/Util.pm
+++ b/lib/Alien/Build/Util.pm
@@ -43,7 +43,7 @@ sub _mirror
   require Alien::Build;
   require File::Find;
   require File::Copy;
-  
+
   File::Find::find({
     wanted => sub {
       next unless -e $File::Find::name;
@@ -99,7 +99,7 @@ sub _mirror
     },
     no_chdir => 1,
   }, "$src_root");
-  
+
   ();
 }
 

--- a/lib/Alien/Build/Version/Basic.pm
+++ b/lib/Alien/Build/Version/Basic.pm
@@ -19,25 +19,25 @@ our @EXPORT_OK = qw( version );
 OO interface:
 
  use Alien::Build::Version::Basic;
- 
+
  my $version = Alien::Build::Version::Basic->new('1.2.3');
  if($version > '1.2.2')  # true
  {
    ...
  }
- 
+
 Function interface:
 
  use Alien::Build::Version::Basic qw( version );
- 
+
  if(version('1.2.3') > version('1.2.2')) # true
  {
    ...
  }
- 
+
  my @sorted = sort map { version($_) } qw( 2.1 1.2.3 1.2.2 );
  # will come out in the order 1.2.2, 1.2.3, 2.1
- 
+
 =head1 DESCRIPTION
 
 This module provides a very basic class for comparing versions.
@@ -61,7 +61,7 @@ compare versions like numbers, or sort them using sort.
  {
    ...
  }
- 
+
  my @sorted = sort map { version($_) } @unsorted;
 
 it also overloads C<""> to stringify as whatever string value you
@@ -136,14 +136,14 @@ sub cmp
 {
   my @a = split /\./, ${$_[0]};
   my @b = split /\./, ${ref($_[1]) ? $_[1] : version($_[1])};
-  
+
   while(@a or @b)
   {
     my $a = (shift @a) || 0;
     my $b = (shift @b) || 0;
     return $a <=> $b if $a <=> $b;
   }
-  
+
   0;
 }
 

--- a/lib/Alien/Role.pm
+++ b/lib/Alien/Role.pm
@@ -9,13 +9,13 @@ use warnings;
 =head1 SYNOPSIS
 
  package Alien::libfoo;
- 
+
  use base qw( Alien::Base );
  use Role::Tiny::With qw( with );
- 
+
  with 'Alien::Role::Dino';
  with 'Alien::Role::Alt';
- 
+
  1;
 
 =head1 DESCRIPTION

--- a/lib/Test/Alien/Build.pm
+++ b/lib/Test/Alien/Build.pm
@@ -32,20 +32,20 @@ our @EXPORT = qw(
 
  use Test2::V0;
  use Test::Alien::Build;
- 
+
  # returns an instance of Alien::Build.
  my $build = alienfile_ok q{
    use alienfile;
-   
+
    plugin 'My::Plugin' => (
      foo => 1,
      bar => 'string',
      ...
    );
  };
- 
+
  alien_build_ok 'builds okay.';
- 
+
  done_testing;
 
 =head1 DESCRIPTION
@@ -131,7 +131,7 @@ sub alienfile
     my $root; # may be undef;
     sub {
       $root ||= Path::Tiny->new(tempdir( CLEANUP => 1 ));
-      
+
       if(@_)
       {
         my $path = $root->child(@_);
@@ -144,7 +144,7 @@ sub alienfile
       }
     };
   };
-  
+
   if($args{source})
   {
     my $file = $get_temp_root->()->child('alienfile');
@@ -159,13 +159,13 @@ sub alienfile
     }
     $args{filename} = path($args{filename})->absolute->stringify;
   }
-  
+
   $args{stage}  ||= $get_temp_root->('stage')->stringify;
   $args{prefix} ||= $get_temp_root->('prefix')->stringify;
   $args{root}   ||= $get_temp_root->('root')->stringify;
 
   require Alien::Build;
-  
+
   _alienfile_clear();
   my $out = capture_merged {
     $build_targ = $args{targ};
@@ -173,7 +173,7 @@ sub alienfile
     $build->set_stage($args{stage});
     $build->set_prefix($args{prefix});
   };
-  
+
   my $ctx = context();
   $ctx->note($out) if $out;
   $ctx->release;
@@ -208,12 +208,12 @@ sub alienfile_ok
   my $build = eval { alienfile(@_) };
   my $error = $@;
   my $ok = !! $build;
-  
+
   my $ctx = context();
   $ctx->ok($ok, 'alienfile compiles');
   $ctx->diag("error: $error") if $error;
   $ctx->release;
-  
+
   $build;
 }
 
@@ -231,12 +231,12 @@ sub alien_install_type_is
 {
   my($type, $name) = @_;
 
-  croak "invalid install type" unless defined $type && $type =~ /^(system|share)$/;  
+  croak "invalid install type" unless defined $type && $type =~ /^(system|share)$/;
   $name ||= "alien install type is $type";
-  
+
   my $ok = 0;
   my @diag;
-  
+
   if($build)
   {
     my($out, $actual) = capture_merged {
@@ -256,7 +256,7 @@ sub alien_install_type_is
   {
     push @diag, 'no alienfile'
   }
-  
+
   my $ctx = context();
   $ctx->ok($ok, $name);
   $ctx->diag($_) for @diag;
@@ -278,13 +278,13 @@ the file or directory if successful.  Returns C<undef> otherwise.
 sub alien_download_ok
 {
   my($name) = @_;
-  
+
   $name ||= 'alien download';
-  
+
   my $ok;
   my $file;
   my @diag;
-  
+
   if($build)
   {
     my($out, $error) = capture_merged {
@@ -320,7 +320,7 @@ sub alien_download_ok
     $ok = 0;
     push @diag, 'no alienfile';
   }
-  
+
   my $ctx = context();
   $ctx->ok($ok, $name);
   $ctx->diag($_) for @diag;
@@ -344,12 +344,12 @@ the directory if successful.  Returns C<undef> otherwise.
 sub alien_extract_ok
 {
   my($archive, $name) = @_;
-  
+
   $name ||= $archive ? "alien extraction of $archive" : 'alien extraction';
   my $ok;
   my $dir;
   my @diag;
-  
+
   if($build)
   {
     my($out, $error);
@@ -386,7 +386,7 @@ sub alien_extract_ok
     $ok = 0;
     push @diag, 'no alienfile';
   }
-  
+
   my $ctx = context();
   $ctx->ok($ok, $name);
   $ctx->diag($_) for @diag;
@@ -433,7 +433,7 @@ sub alien_build_ok
   my @diag;
   my @note;
   my $alien;
-  
+
   if($build)
   {
     my($out,$error) = capture_merged {
@@ -454,27 +454,27 @@ sub alien_build_ok
     else
     {
       $ok = 1;
-      
+
       push @note, $out if defined $out;
-      
+
       require Alien::Base;
-      
+
       my $prefix = $build->runtime_prop->{prefix};
       my $stage  = $build->install_prop->{stage};
       my %prop   = %{ $build->runtime_prop };
-      
+
       $prop{distdir} = $prefix;
-      
+
       _mirror $stage, $prefix;
-      
+
       my $dist_dir = sub {
         $prefix;
       };
-      
+
       my $runtime_prop = sub {
         \%prop;
       };
-      
+
       $alien = sprintf 'Test::Alien::Build::Faux%04d', $count++;
       {
         no strict 'refs';
@@ -489,13 +489,13 @@ sub alien_build_ok
     $ok = 0;
     push @diag, 'no alienfile';
   }
-  
+
   my $ctx = context();
   $ctx->ok($ok, $name);
   $ctx->diag($_) for @diag;
   $ctx->note($_) for @note;
   $ctx->release;
-  
+
   $alien;
 }
 
@@ -539,11 +539,11 @@ Test the checkpoint of a build.
 sub alien_checkpoint_ok
 {
   my($name) = @_;
-  
+
   $name ||= "alien checkpoint ok";
   my $ok;
   my @diag;
-  
+
   if($build)
   {
     eval { $build->checkpoint };
@@ -563,12 +563,12 @@ sub alien_checkpoint_ok
     push @diag, "no build to checkpoint";
     $ok = 0;
   }
-  
+
   my $ctx = context();
   $ctx->ok($ok, $name);
   $ctx->diag($_) for @diag;
   $ctx->release;
-  
+
   $ok;
 }
 
@@ -584,11 +584,11 @@ Test a resume a checkpointed build.
 sub alien_resume_ok
 {
   my($name) = @_;
-  
+
   $name ||= "alien resume ok";
   my $ok;
   my @diag;
-  
+
   if($build_alienfile && $build_root && !defined $build)
   {
     $build = eval { Alien::Build->resume($build_alienfile, "$build_root/root") };
@@ -614,12 +614,12 @@ sub alien_resume_ok
     }
     $ok = 0;
   }
-  
+
   my $ctx = context();
   $ctx->ok($ok, $name);
   $ctx->diag($_) for @diag;
-  $ctx->release;  
-  
+  $ctx->release;
+
   ($ok && $build) || $ok;
 }
 
@@ -628,7 +628,7 @@ sub alien_resume_ok
  alien_rc $code;
 
 Creates C<rc.pl> file in a temp directory and sets ALIEN_BUILD_RC.  Useful for testing
-plugins that should be called from C<~/.alienbuild/rc.pl>.  Note that because of the 
+plugins that should be called from C<~/.alienbuild/rc.pl>.  Note that because of the
 nature of how the C<~/.alienbuild/rc.pl> file works, you can only use this once!
 
 =cut
@@ -636,10 +636,10 @@ nature of how the C<~/.alienbuild/rc.pl> file works, you can only use this once!
 sub alien_rc
 {
   my($code) = @_;
-  
+
   croak "passed in undef rc" unless defined $code;
   croak "looks like you have already defined a rc.pl file" if $ENV{ALIEN_BUILD_RC} ne '-';
-  
+
   my(undef, $filename, $line) = caller;
   my $code2 = "use strict; use warnings;\n" .
               '# line ' . $line . ' "' . path($filename)->absolute . "\n$code";
@@ -668,9 +668,9 @@ sub alien_subtest
   my $ctx = context();
   my $pass = run_subtest($name, $code, { buffered => 1 }, @args);
   $ctx->release;
-  
+
   _alienfile_clear;
-  
+
   $pass;
 }
 

--- a/lib/Test/Alien/Run.pm
+++ b/lib/Test/Alien/Run.pm
@@ -11,7 +11,7 @@ use Test2::API qw( context );
 
  use Test2::V0;
  use Test::Alien;
- 
+
  run_ok([ $^X, -e => 'print "some output"; exit 22'])
    ->exit_is(22)
    ->out_like(qr{some});
@@ -100,10 +100,10 @@ Passes if the process terminated with the given exit value.
 sub exit_is
 {
   my($self, $exit, $message) = @_;
-  
+
   $message ||= "command exited with value $exit";
   my $ok = $self->exit == $exit;
-  
+
   my $ctx = context();
   $ctx->ok($ok, $message);
   $ctx->diag("  actual exit value was: @{[ $self->exit ]}") unless $ok;
@@ -124,10 +124,10 @@ but the given value.
 sub exit_isnt
 {
   my($self, $exit, $message) = @_;
-  
+
   $message ||= "command exited with value not $exit";
   my $ok = $self->exit != $exit;
-  
+
   my $ctx = context();
   $ctx->ok($ok, $message);
   $ctx->diag("  actual exit value was: @{[ $self->exit ]}") unless $ok;
@@ -147,11 +147,11 @@ Passes if the output of the run matches the given pattern.
 sub _like
 {
   my($self, $regex, $source, $not, $message) = @_;
-  
+
   my $ok = $self->{$source} =~ $regex;
   $ok = !$ok if $not;
-  
-  my $ctx = context();  
+
+  my $ctx = context();
   $ctx->ok($ok, $message);
   unless($ok)
   {
@@ -161,7 +161,7 @@ sub _like
     $ctx->diag("    $regex");
   }
   $ctx->release;
-  
+
   $self;
 }
 
@@ -231,7 +231,7 @@ Send the output and standard error as test note.
 sub note
 {
   my($self) = @_;
-  my $ctx = context();  
+  my $ctx = context();
   $ctx->note("[cmd]");
   $ctx->note("  @{$self->{cmd}}");
   if($self->out ne '')

--- a/lib/Test/Alien/Synthetic.pm
+++ b/lib/Test/Alien/Synthetic.pm
@@ -11,14 +11,14 @@ use Test2::API qw( context );
 
  use Test2::V0;
  use Test::Alien;
- 
+
  plan 1;
- 
+
  my $alien = synthetic {
    cflags => '-I/foo/bar/include',
    libs   => '-L/foo/bar/lib -lbaz',
  };
- 
+
  alien_ok $alien;
 
 =head1 DESCRIPTION
@@ -115,18 +115,18 @@ based L<Alien> distribution.
  use Test2::V0;
  use Test::Alien;
  use Alien::Libarchive;
- 
+
  plan 5;
- 
+
  my $real = Alien::Libarchive->new;
  my $alien = synthetic {
    cflags       => scalar $real->cflags,
    libs         => scalar $real->libs,
    dynamic_libs => [$real->dlls],
  };
- 
+
  alien_ok $alien;
- 
+
  xs_ok do { local $/; <DATA> }, with_subtest {
    my($module) = @_;
    plan 1;
@@ -134,7 +134,7 @@ based L<Alien> distribution.
    like $ptr, qr{^[0-9]+$};
    $module->archive_read_free($ptr);
  };
- 
+
  ffi_ok { symbols => [qw( archive_read_new )] }, with_subtest {
    my($ffi) = @_;
    my $new  = $ffi->function(archive_read_new => [] => 'opaque');
@@ -143,23 +143,23 @@ based L<Alien> distribution.
    like $ptr, qr{^[0-9]+$};
    $free->($ptr);
  };
- 
+
  __DATA__
- 
+
  #include "EXTERN.h"
  #include "perl.h"
  #include "XSUB.h"
  #include <archive.h>
- 
+
  MODULE = TA_MODULE PACKAGE = TA_MODULE
- 
+
  void *archive_read_new(class);
      const char *class;
    CODE:
      RETVAL = (void*) archive_read_new();
    OUTPUT:
      RETVAL
- 
+
  void archive_read_free(class, ptr);
      const char *class;
      void *ptr;

--- a/lib/alienfile.pm
+++ b/lib/alienfile.pm
@@ -17,28 +17,28 @@ sub _path { Path::Tiny::path(@_) }
 Do-it-yourself approach:
 
  use alienfile;
- 
+
  probe [ 'pkg-config --exists libarchive' ];
- 
+
  share {
-   
+
    start_url 'http://libarchive.org/downloads/libarchive-3.2.2.tar.gz';
-   
+
    # the first one which succeeds will be used
    download [ 'wget %{.meta.start_url}' ];
    download [ 'curl -o %{.meta.start_url}' ];
-   
+
    extract [ 'tar xf %{.install.download}' ];
-   
-   build [ 
+
+   build [
      # Note: will not work on Windows, better to use Build::Autoconf plugin
      # if you need windows support
      './configure --prefix=%{.install.prefix} --disable-shared',
      '%{make}',
      '%{make} install',
-   ];   
+   ];
  }
- 
+
  gather [
    [ 'pkg-config', '--modversion', 'libarchive', \'%{.runtime.version}' ],
    [ 'pkg-config', '--cflags',     'libarchive', \'%{.runtime.cflags}'  ],
@@ -48,9 +48,9 @@ Do-it-yourself approach:
 With plugins (better):
 
  use alienfile;
- 
+
  plugin 'PkgConfig' => 'libarchive';
- 
+
  share {
    start_url 'http://libarchive.org/downloads/';
    plugin Download => (
@@ -157,7 +157,7 @@ Examples:
  # which will pick the best Alien::Build::Plugin::Fetch
  # plugin based on the URL, and system configuration
  plugin 'Fetch' => 'http://ftp.gnu.org/gnu/gcc';
- 
+
  # loads the plugin with the badly named class!
  plugin '=Badly::Named::Plugin::Not::In::Alien::Build::Namespace';
 
@@ -166,13 +166,13 @@ Examples:
    filter => qr/^gcc-.*\.tar\.gz$/,
    version => qr/([0-9\.]+)/,
  );
- 
+
 =cut
 
 sub plugin
 {
   my($name, @args) = @_;
-  
+
   my $caller = caller;
   $caller->meta->apply_plugin($name, @args);
   return;
@@ -491,12 +491,12 @@ sub build_ffi
 
  gather \&code;
  gather \@commandlist;
- 
+
  share {
    gather \&code;
    gather \@commandlist;
  };
- 
+
  sys {
    gather \&code;
    gather \@commandlist;
@@ -637,9 +637,9 @@ sub test
   my $phase = $meta->{phase};
   Carp::croak "test is not allowed in $phase block"
     if $phase eq 'any' || $phase eq 'configure';
-  
+
   $meta->add_requires('configure' => 'Alien::Build' => '1.14');
-  
+
   if($phase eq 'share')
   {
     my $suffix = $caller->meta->{build_suffix} || '_share';

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -91,7 +91,7 @@ pass 'okay';
 
 my $max = 1;
 $max = $_ > $max ? $_ : $max for map { length $_ } @modules;
-our $format = "%-${max}s %s"; 
+our $format = "%-${max}s %s";
 
 spacer;
 
@@ -100,13 +100,13 @@ my @keys = sort grep /(MOJO|PERL|\A(LC|HARNESS)_|\A(SHELL|LANG)\Z)/i, keys %ENV;
 if(@keys > 0)
 {
   diag "$_=$ENV{$_}" for @keys;
-  
+
   if($ENV{PERL5LIB})
   {
     spacer;
     diag "PERL5LIB path";
     diag $_ for split $Config{path_sep}, $ENV{PERL5LIB};
-    
+
   }
   elsif($ENV{PERLLIB})
   {
@@ -114,7 +114,7 @@ if(@keys > 0)
     diag "PERLLIB path";
     diag $_ for split $Config{path_sep}, $ENV{PERLLIB};
   }
-  
+
   spacer;
 }
 

--- a/t/alien_base.t
+++ b/t/alien_base.t
@@ -31,7 +31,7 @@ my $mock = Test2::Mock->new(
         else
         {
           return;
-        } 
+        }
       }
     },
   ],
@@ -64,7 +64,7 @@ subtest 'AB::MB share install' => sub {
   my $cflags  = Alien::Foo2->cflags;
   my $libs    = Alien::Foo2->libs;
   my $version = Alien::Foo2->version;
-    
+
   ok $cflags,  "cflags: $cflags";
   ok $libs,    "libs:   $libs";
   is $version, '3.2.1', "version: $version";
@@ -72,7 +72,7 @@ subtest 'AB::MB share install' => sub {
   (first { /^-I/ } shellwords($cflags)) =~ /^-I(.*)$/;
   ok defined $1 && -f "$1/foo2.h", "include path";
   note "include path: $1";
-  
+
   (first { /^-L/ } shellwords($libs)) =~ /^-L(.*)$/;
   ok defined $1 && -f "$1/libfoo2.a", "lib path";
   note "lib path: $1";
@@ -82,36 +82,36 @@ subtest 'AB::MB share install' => sub {
 subtest 'Alien::Build system' => sub {
 
   require Alien::libfoo1;
-  
+
   is( -f path(Alien::libfoo1->dist_dir)->child('_alien/for_libfoo1'), T(), 'dist_dir');
   is( Alien::libfoo1->cflags, '-DFOO=1', 'cflags' );
   is( Alien::libfoo1->cflags_static, '-DFOO=1 -DFOO_STATIC=1', 'cflags_static');
   is( Alien::libfoo1->libs, '-lfoo', 'libs' );
   is( Alien::libfoo1->libs_static, '-lfoo -lbar -lbaz', 'libs_static' );
   is( Alien::libfoo1->version, '1.2.3', 'version');
-  
+
   subtest 'install type' => sub {
     is( Alien::libfoo1->install_type, 'system' );
     is( Alien::libfoo1->install_type('system'), T() );
     is( Alien::libfoo1->install_type('share'), F() );
   };
-  
+
   is( Alien::libfoo1->config('name'), 'foo', 'config.name' );
   is( Alien::libfoo1->config('finished_installing'), T(), 'config.finished_installing' );
 
   is( [Alien::libfoo1->dynamic_libs], ['/usr/lib/libfoo.so','/usr/lib/libfoo.so.1'], 'dynamic_libs' );
-  
+
   is( [Alien::libfoo1->bin_dir], [], 'bin_dir' );
-  
+
   is( Alien::libfoo1->runtime_prop->{arbitrary}, 'one', 'runtime_prop' );
 };
 
 subtest 'Alien::Build share' => sub {
 
   require Alien::libfoo2;
-  
+
   is( -f path(Alien::libfoo2->dist_dir)->child('_alien/for_libfoo2'), T(), 'dist_dir');
-  
+
   subtest 'cflags' => sub {
     is(
       [shellwords(Alien::libfoo2->cflags)],
@@ -122,15 +122,15 @@ subtest 'Alien::Build share' => sub {
       },
       'cflags',
     );
-    
+
     my($dir) = [shellwords(Alien::libfoo2->cflags)]->[0] =~ /^-I(.*)$/;
-    
+
     is(
       -f path($dir)->child('foo.h'),
       T(),
       '-I directory points to foo.h location',
     );
-  
+
     is(
       [shellwords(Alien::libfoo2->cflags_static)],
       array {
@@ -141,18 +141,18 @@ subtest 'Alien::Build share' => sub {
       },
       'cflags_static',
     );
-    
+
     ($dir) = [shellwords(Alien::libfoo2->cflags_static)]->[0] =~ /^-I(.*)$/;
-    
+
     is(
       -f path($dir)->child('foo.h'),
       T(),
       '-I directory points to foo.h location (static)',
     );
   };
-  
+
   subtest 'libs' => sub {
-  
+
     is(
       [shellwords(Alien::libfoo2->libs)],
       array {
@@ -162,16 +162,16 @@ subtest 'Alien::Build share' => sub {
       },
       'libs',
     );
-    
+
     my($dir) = [shellwords(Alien::libfoo2->libs)]->[0] =~ /^-L(.*)$/;
-    
+
     is(
       -f path($dir)->child('libfoo.a'),
       T(),
       '-L directory points to libfoo.a location',
     );
-    
-    
+
+
     is(
       [shellwords(Alien::libfoo2->libs_static)],
       array {
@@ -183,28 +183,28 @@ subtest 'Alien::Build share' => sub {
       },
       'libs_static',
     );
-    
+
     ($dir) = [shellwords(Alien::libfoo2->libs_static)]->[0] =~ /^-L(.*)$/;
-    
+
     is(
       -f path($dir)->child('libfoo.a'),
       T(),
       '-L directory points to libfoo.a location (static)',
     );
-  
+
   };
-  
+
   is( Alien::libfoo2->version, '2.3.4', 'version' );
-  
+
   subtest 'install type' => sub {
     is( Alien::libfoo2->install_type, 'share' );
     is( Alien::libfoo2->install_type('system'), F() );
     is( Alien::libfoo2->install_type('share'), T() );
   };
-  
+
   is( Alien::libfoo2->config('name'), 'foo', 'config.name' );
   is( Alien::libfoo2->config('finished_installing'), T(), 'config.finished_installing' );
-  
+
   is(
     [Alien::libfoo2->dynamic_libs],
     array {
@@ -214,7 +214,7 @@ subtest 'Alien::Build share' => sub {
     },
     'dynamic_libs',
   );
-  
+
   is(
     [Alien::libfoo2->bin_dir],
     array {
@@ -223,9 +223,9 @@ subtest 'Alien::Build share' => sub {
     },
     'bin_dir',
   );
-  
+
   is( -f path(Alien::libfoo2->bin_dir)->child('foo-config'), T(), 'has a foo-config');
-  
+
   is( Alien::libfoo2->runtime_prop->{arbitrary}, 'two', 'runtime_prop' );
 
 };
@@ -239,7 +239,7 @@ subtest 'build flags' => sub {
   my %win_flags = (
     q{ -L/a/b/c -lz -L/a/b/c } => [ "-L/a/b/c", "-lz", "-L/a/b/c" ],
     q{ -LC:/a/b/c -lz -L"C:/a/b c/d" } => [ "-LC:/a/b/c", "-lz", "-LC:/a/b c/d" ],
-    q{ -LC:\a\b\c -lz } => [ q{-LC:\a\b\c}, "-lz" ], 
+    q{ -LC:\a\b\c -lz } => [ q{-LC:\a\b\c}, "-lz" ],
   );
 
   subtest 'unix' => sub {
@@ -259,9 +259,9 @@ subtest 'build flags' => sub {
 subtest 'ffi_name' => sub {
 
   require Alien::libfoo1;
-  
+
   my @args_find_lib;
-  
+
   my $mock1 = Test2::Mock->new(
     'class' => 'FFI::CheckLib',
     override => [
@@ -271,10 +271,10 @@ subtest 'ffi_name' => sub {
       },
     ],
   );
-  
+
   is( [Alien::libfoo1->dynamic_libs], ['foo.dll','foo2.dll'], 'call dynamic_libs' );
   is( \@args_find_lib, [ lib => 'foo' ] );
-  
+
   my $mock2 = Test2::Mock->new(
     class => 'Alien::Base',
     around => [
@@ -285,7 +285,7 @@ subtest 'ffi_name' => sub {
       },
     ],
   );
-  
+
   is( [Alien::libfoo1->dynamic_libs], ['foo.dll','foo2.dll'], 'call dynamic_libs' );
   is( \@args_find_lib, [ lib => 'roger' ] );
 

--- a/t/alien_base__system_installed.t
+++ b/t/alien_base__system_installed.t
@@ -48,7 +48,7 @@ subtest 'basic' => sub {
   my $gard = system_fake
     'pkg-config' => sub {
       my(@args) = @_;
-    
+
       if($args[0] eq '--modversion' && $args[1])
       {
         print "1.2.3\n";
@@ -64,7 +64,7 @@ subtest 'basic' => sub {
         print "$libs \n";
         return 0;
       }
-    
+
       use Alien::Build::Util qw( _dump );
       diag _dump(\@args);
       ok 0, 'bad command';
@@ -89,12 +89,12 @@ subtest 'basic' => sub {
 
   my($builder) = do {
     my($out, $builder) = capture_merged {
-      Alien::Base::ModuleBuild->new( 
+      Alien::Base::ModuleBuild->new(
         module_name => 'MyTest',
         dist_version => 0.01,
         alien_name => $lib,
         share_dir => 't',
-      ); 
+      );
     };
     note $out;
     $builder;
@@ -105,17 +105,17 @@ subtest 'basic' => sub {
   {
     local $CWD;
     push @CWD, qw/blib lib/;
-  
+
     use lib '.';
     require './MyTest.pm';
     my $alien = MyTest->new;
-  
+
     isa_ok($alien, 'MyTest');
     isa_ok($alien, 'Alien::Base');
-  
+
     note "alien->cflags = ", $alien->cflags;
     note "alien->libs   = ", $alien->libs;
-  
+
     is($alien->cflags, $cflags, "get cflags from system-installed library");
     is($alien->libs  , $libs  , "get libs from system-installed library"  );
   }

--- a/t/alien_base_pkgconfig.t
+++ b/t/alien_base_pkgconfig.t
@@ -15,8 +15,8 @@ subtest 'basic' => sub {
   ok( -d $pcfiledir, 'pcfiledir is a directory' );
   ok( -e "$pcfiledir/test.pc", 'pcfiledir contains test.pc' );
 
-  is( 
-    $pc->{vars}, 
+  is(
+    $pc->{vars},
     {
       'INTERNAL_VARIABLE' => '-lotherlib',
       'prefix' => '/home/test/path',
@@ -58,9 +58,9 @@ subtest 'basic' => sub {
   is( $pc->keyword('Cflags'), '-Dfoo=bar -I/home/test/path/deeper/include', "multiple interpolation keyword" );
 
   # interpolate with overrides
-  is( 
-    $pc->keyword( 'Cflags', {prefix => '/some/other/path'}), 
-    '-Dfoo=bar -I/some/other/path/deeper/include', 
+  is(
+    $pc->keyword( 'Cflags', {prefix => '/some/other/path'}),
+    '-Dfoo=bar -I/some/other/path/deeper/include',
     "multiple interpolation keyword with override"
   );
 
@@ -82,11 +82,11 @@ subtest 'version' => sub {
   skip_all "pkg-config returned no packages" unless @installed;
   my $lib = $installed[0];
 
-  my ($builder_ok, $builder_bad) = map { 
+  my ($builder_ok, $builder_bad) = map {
     require Alien::Base::ModuleBuild;
     my($out, $builder) = capture_merged {
-      Alien::Base::ModuleBuild->new( 
-        module_name => 'My::Test', 
+      Alien::Base::ModuleBuild->new(
+        module_name => 'My::Test',
         dist_version => 0.01,
         alien_name => $_,
         share_dir => 't',
@@ -98,25 +98,25 @@ subtest 'version' => sub {
   ($lib, 'siughspidghsp');
 
   subtest 'good' => sub {
-  
+
     my($out, $value) = capture_merged {
       $builder_ok->alien_check_installed_version,
     };
     note $out if $out ne '';
-    
+
     is( $value, T(), 'found installed library' );
     note "lib is $lib";
-  
+
   };
-  
+
   subtest 'bad' => sub {
     my($out, $value) = capture_merged {
       $builder_bad->alien_check_installed_version,
     };
     note $out if $out ne '';
-    
+
     is( $value, F(), "returns false if not found");
-    
+
   };
 };
 

--- a/t/alien_base_wrapper.t
+++ b/t/alien_base_wrapper.t
@@ -14,22 +14,22 @@ subtest 'export' => sub {
     package
       Alien::Foo1;
 
-    sub install_type { 'share' }    
+    sub install_type { 'share' }
     sub cflags {}
     sub libs {}
 
     package
       Alien::Bar1;
 
-    sub install_type { 'share' }    
+    sub install_type { 'share' }
     sub cflags {}
     sub libs {}
-  
+
     package
       Foo::Bar1;
     use Alien::Base::Wrapper qw( Alien::Foo1 Alien::Bar1 );
   }
-  
+
   ok(
     Foo::Bar1->can('cc'),
     'can cc',
@@ -49,16 +49,16 @@ subtest 'system' => sub {
   {
     package
       Alien::Foo2;
-    
+
     sub install_type { 'system' }
     sub cflags { '-I/foo/include -DBAR=1' }
     sub cflags_static { 'wrong' }
     sub libs   { '-L/foo/lib -lfoo'   }
     sub libs_static { 'wrong' }
   }
-  
+
   Alien::Base::Wrapper->import('Foo2');
-  
+
   is(
     exec_arrayref {
       local @ARGV = qw( one two three );
@@ -86,14 +86,14 @@ subtest 'share' => sub {
   {
     package
       Alien::Foo3;
-    
+
     sub install_type { 'share' }
     sub cflags { '-I/foo/include -DBAR=1' }
     sub cflags_static { '-I/foo/include -DBAR=2' }
     sub libs   { '-L/foo/lib -lfoo'   }
     sub libs_static { '-L/foo/lib -lfoo -lbaz' }
   }
-  
+
   Alien::Base::Wrapper->import('Alien::Foo3');
 
   is(
@@ -123,12 +123,12 @@ subtest 'share sans static' => sub {
   {
     package
       Alien::Foo4;
-    
+
     sub install_type { 'share' }
     sub cflags { '-I/foo/include -DBAR=1' }
     sub libs   { '-L/foo/lib -lfoo'   }
   }
-  
+
   Alien::Base::Wrapper->import('Alien::Foo4');
 
   is(
@@ -154,25 +154,25 @@ subtest 'share sans static' => sub {
 subtest 'combine aliens' => sub {
 
   Alien::Base::Wrapper::_reset();
-  
+
   {
     package
       Alien::Foo5;
-      
+
     sub install_type { 'system' }
     sub cflags { '-I/foo/include -DFOO5=1' }
     sub libs   { '-L/foo/lib --ld-foo -lfoo' }
-    
+
     package
       Alien::Bar5;
-    
+
     sub install_type { 'share' }
     sub cflags { '-I/bar/include -DBAR5=1' }
     sub libs   { '-L/foo/lib --ld-bar -lbar' }
   }
 
   Alien::Base::Wrapper->import('Alien::Foo5', 'Alien::Bar5');
-  
+
   is(
     exec_arrayref {
       local @ARGV = qw( one two three );
@@ -207,15 +207,15 @@ subtest 'combine aliens' => sub {
         field LDFLAGS   => T();
       },
     );
-    
+
   };
-  
+
   subtest 'mb_args' => sub {
 
     my %mb_args = Alien::Base::Wrapper->mb_args;
 
     note _dump(\%mb_args);
-    
+
     is(
       \%mb_args,
       hash {
@@ -227,7 +227,7 @@ subtest 'combine aliens' => sub {
         };
       },
     );
-  
+
 
   };
 

--- a/t/alien_build.t
+++ b/t/alien_build.t
@@ -18,7 +18,7 @@ subtest 'simple new' => sub {
     isa_ok( MyBuild->meta, 'Alien::Build::Meta' );
     note(_dump $build->meta);
   };
-  
+
   subtest 'with meta_prop in new' => sub {
     my $build = MyBuild2->new(meta_prop => { roger => 1, ramjet => [ 1,2,3] });
     note(_dump $build->meta->prop);
@@ -38,7 +38,7 @@ subtest 'simple new' => sub {
 subtest 'from file' => sub {
 
   my $build = Alien::Build->load('corpus/basic/alienfile');
-  
+
   isa_ok $build, 'Alien::Build';
 
   isa_ok( $build->meta, 'Alien::Build::Meta' );
@@ -68,9 +68,9 @@ subtest 'load requires' => sub {
 
     my $build = alienfile q{ use alienfile };
     my $meta = $build->meta;
-  
+
     note(_dump $meta);
-  
+
     is( $build->load_requires, 1, 'empty loads okay' );
 
     $meta->add_requires( 'any' => 'Foo::Bar::Baz' => '1.00');
@@ -90,12 +90,12 @@ subtest 'hook' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   subtest 'simple single working hook' => sub {
-  
+
     my @foo1;
     my $props;
-  
+
     $meta->register_hook(
       foo1 => sub {
         @foo1 = @_;
@@ -104,9 +104,9 @@ subtest 'hook' => sub {
         return 42;
       }
     );
-  
-    is( $build->hook_prop, undef );  
-  
+
+    is( $build->hook_prop, undef );
+
     is( $build->_call_hook(foo1 => ('roger', 'ramjet')), 42);
 
     is(
@@ -117,7 +117,7 @@ subtest 'hook' => sub {
       },
     );
 
-    is( $build->hook_prop, undef );  
+    is( $build->hook_prop, undef );
 
     is(
       \@foo1,
@@ -133,96 +133,96 @@ subtest 'hook' => sub {
   };
 
   my $exception_count = 0;
-  
+
   $meta->register_hook(
     foo2 => sub {
       $exception_count++;
       die "throw exception";
     }
   );
-  
+
   subtest 'single failing hook' => sub {
-    
+
     $exception_count = 0;
-    
+
     eval { $build->_call_hook(foo2 => ()) };
     like $@, qr/throw exception/;
     note "error = $@";
     is $exception_count, 1;
-  
+
   };
-  
+
   subtest 'one fail, one okay' => sub {
-  
+
     $exception_count = 0;
-    
+
     $meta->register_hook(
       foo2 => sub {
         99;
       }
     );
-    
+
     is( $build->_call_hook(foo2 => ()), 99);
     is $exception_count, 1;
-  
+
   };
-  
+
   subtest 'invalid hook' => sub {
-  
+
     eval { $build->_call_hook(foo3 => ()) };
     like $@, qr/No hooks registered for foo3/;
-  
+
   };
-  
+
   subtest 'command list hook' => sub {
-  
+
     $meta->register_hook(
       foo4 => [[$^X, -e => 'print @ARGV', 'hello', ' ', 'world']],
     );
-    
+
     my $out = capture_merged { $build->_call_hook('foo4') };
     note $out;
-    
+
     like $out, qr/hello world/s;
-  
+
   };
-  
+
   subtest 'command with failure' => sub {
-  
+
     $meta->register_hook(
       foo5 => [[$^X, -e => 'exit 1']],
     );
-    
+
     my $error;
     note capture_merged {
       eval { $build->_call_hook('foo5') };
       $error = $@;
     };
-    
+
     like $error, qr/external command failed/;
-  
+
   };
-  
+
   subtest 'command with failure, followed by good command' => sub {
-  
+
     $meta->register_hook(
       foo5 => [[$^X, -e => '']],
     );
-    
+
     note capture_merged {
       $build->_call_hook('foo5');
     };
-    
+
     ok 1;
-  
+
   };
-  
+
   subtest 'around hook' => sub {
-  
+
     subtest 'single wrapper' => sub {
-    
+
       my @args;
-    
+
       $meta->register_hook(
         foo6 => sub {
           my $build = shift;
@@ -231,23 +231,23 @@ subtest 'hook' => sub {
           return 'platypus';
         },
       );
-      
+
       $meta->around_hook(
         foo6 => sub {
           my $orig = shift;
           return $orig->(@_) . ' man';
         }
       );
-      
+
       is( $build->_call_hook('foo6', 1, 2), 'platypus man', 'return value' );
       is( \@args, [1,2], 'arguments' );
-    
+
     };
-    
+
     subtest 'double wrapper' => sub {
-    
+
       my @args;
-    
+
       $meta->register_hook(
         foo7 => sub {
           my $build = shift;
@@ -256,30 +256,30 @@ subtest 'hook' => sub {
           return 'platypus';
         },
       );
-      
+
       $meta->around_hook(
         foo7 => sub {
           my $orig = shift;
           return '(' . $orig->(@_) . ') man';
         }
       );
-      
+
       $meta->around_hook(
         foo7 => sub {
           my $orig = shift;
           return 'the (' . $orig->(@_) . ')';
         }
       );
-      
+
       is( $build->_call_hook('foo7', 1, 2), 'the ((platypus) man)', 'return value' );
       is( \@args, [1,2], 'arguments' );
-    
+
     };
-    
+
     subtest 'alter args' => sub {
-    
+
       my @args;
-      
+
       $meta->register_hook(
         foo8 => sub {
           my $build = shift;
@@ -288,7 +288,7 @@ subtest 'hook' => sub {
           return 'platypus';
         },
       );
-      
+
       $meta->around_hook(
         foo8 => sub {
           my $orig = shift;
@@ -296,12 +296,12 @@ subtest 'hook' => sub {
           $orig->($build, map { $_ + 1 } @_);
         }
       );
-      
+
       is( $build->_call_hook('foo8', 1, 2), 'platypus' );
       is( \@args, [ 2,3 ] );
-    
+
     };
-  
+
   };
 
 };
@@ -309,58 +309,58 @@ subtest 'hook' => sub {
 subtest 'probe' => sub {
 
   subtest 'system' => sub {
-  
+
     my $build = alienfile filename => 'corpus/blank/alienfile';
     my $meta = $build->meta;
-    
+
     $meta->register_hook(
       probe => sub {
         note "dir = $CWD";
         return 'system';
       },
     );
-    
+
     is($build->probe, 'system');
     is($build->runtime_prop->{install_type}, 'system');
-  
+
   };
-  
+
   subtest 'share' => sub {
 
     my $build = alienfile filename => 'corpus/blank/alienfile';
     my $meta = $build->meta;
-    
+
     $meta->register_hook(
       probe => sub {
         note "dir = $CWD";
         return 'system';
       },
     );
-    
+
     is($build->probe, 'system');
     is($build->runtime_prop->{install_type}, 'system');
-  
+
   };
-  
+
   subtest 'throw exception' => sub {
-  
+
     my $build = alienfile filename => 'corpus/blank/alienfile';
     my $meta = $build->meta;
-    
+
     $meta->register_hook(
       probe => sub {
         note "dir = $CWD";
         die "error will robinson!";
       },
     );
-    
+
     my $type;
     note capture_merged { $type = $build->probe };
     is($type, 'share');
     is($build->runtime_prop->{install_type}, 'share');
-  
+
   };
-  
+
 };
 
 subtest 'gather system' => sub {
@@ -369,13 +369,13 @@ subtest 'gather system' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $meta->register_hook(
     probe => sub {
       'system';
     }
   );
-  
+
   $meta->register_hook(
     gather_system => sub {
       my($build) = @_;
@@ -384,14 +384,14 @@ subtest 'gather system' => sub {
       $build->runtime_prop->{version} = '1.2.3';
     },
   );
-  
+
   if($build->install_type eq 'system')
   {
     note capture_merged {
       $build->build;
     };
   }
-  
+
   is(
     $build->runtime_prop,
     hash {
@@ -402,7 +402,7 @@ subtest 'gather system' => sub {
     },
     'runtime props'
   );
-  
+
   is(
     $build->install_prop,
     hash {
@@ -435,7 +435,7 @@ subtest 'download' => sub {
     my($build) = @_;
 
     note scalar capture_merged { $build->download };
-     
+
     is(
       $build->install_prop,
       hash {
@@ -448,60 +448,60 @@ subtest 'download' => sub {
       },
       'install props'
     );
-      
+
     note "build.install_prop.download=@{[ $build->install_prop->{download} ]}";
-        
+
     is(
       path($build->install_prop->{download})->slurp_raw,
       $tarpath->slurp_raw,
       'file matches',
     );
-  };  
+  };
 
   subtest 'component' => sub {
 
     foreach my $file_as (qw( content path ))
     {
-  
+
       subtest "single download with file as $file_as" => sub {
-    
+
         my($build, $meta) = $build->(
           url            => 'http://test1.test/foo/bar/baz/foo-1.00.tar.gz',
           return_file_as => $file_as,
         );
-      
+
         $check->($build);
-    
+
       };
     }
-    
+
     foreach my $listing_as (qw( list html dir_listing ))
     {
-    
+
       subtest "listing download with listing as $listing_as" => sub {
-      
+
         my($build, $meta) = $build->(
           url               => 'http://test1.test/foo/bar/baz/',
           return_listing_as => $listing_as,
         );
-        
+
         $check->($build);
-      
+
       };
-    
+
     }
-  
+
   };
-  
+
   subtest 'command single' => sub {
-  
+
     my $guard = system_fake
       wget => sub {
         my($url) = @_;
-        
+
         # just pretend that we have some hidden files
         path('.foo')->touch;
-        
+
         if($url eq 'http://test1.test/foo/bar/baz/foo-1.00.tar.gz')
         {
           print "200 found $url!\n";
@@ -514,55 +514,55 @@ subtest 'download' => sub {
           return 2;
         }
       };
-    
+
     my $build = alienfile filename => 'corpus/blank/alienfile';
     my $meta = $build->meta;
-    
+
     $meta->register_hook(
       download => [ "wget http://test1.test/foo/bar/baz/foo-1.00.tar.gz" ],
     );
-    
+
     $check->($build);
-  
+
   };
-  
+
   subtest 'command no file' => sub {
-  
+
     my $guard = system_fake
       true => sub {
         0;
       };
-    
+
     my $build = alienfile filename => 'corpus/blank/alienfile';
     my $meta = $build->meta;
-    
+
     $meta->register_hook(
       download => [ 'true' ],
     );
-    
+
     my($out, $error) = capture_merged { eval { $build->download }; $@ };
     note $out;
     like $error, qr/no files downloaded/, 'diagnostic failure';
-  
+
   };
-  
+
   subtest 'command multiple files' => sub {
-  
+
     my $guard = system_fake
       explode => sub {
         path($_)->touch for map { "$_.txt" } qw( foo bar baz );
         0;
       };
-    
+
     my $build = alienfile filename => 'corpus/blank/alienfile';
     my $meta = $build->meta;
-    
+
     $meta->register_hook(
       download => ['explode'],
     );
-    
+
     note scalar capture_merged { $build->download };
-    
+
     is(
       $build->install_prop,
       hash {
@@ -575,13 +575,13 @@ subtest 'download' => sub {
       },
       'install props'
     );
-    
+
     my $dir = path($build->install_prop->{download});
     ok(-d $dir, "dir exists");
     ok(-f $dir->child($_), "file $_ exists") for map { "$_.txt" } qw( foo bar baz );
-  
+
   };
-  
+
 };
 
 alien_subtest 'extract' => sub {
@@ -591,24 +591,24 @@ alien_subtest 'extract' => sub {
     my $plugin = Alien::Build::Plugin::Extract::CommandLine->new;
     $plugin->tar_cmd;
   };
-  
+
   skip_all 'test requires command line tar' unless $tar_cmd;
 
   my $build = alienfile_ok q{
     use alienfile;
   };
   my $meta = $build->meta;
-  
+
   $meta->register_hook(
     extract => [ [ $tar_cmd, "xf", "%{alien.install.download}"] ],
   );
-  
+
   $build->install_prop->{download} = path("corpus/dist/foo-1.00.tar")->absolute->stringify;
-  
+
   my($out, $dir, $error) = capture_merged { (eval { $build->extract }, $@) };
-  
+
   note $out if $out ne '';
-  
+
   is $error, '', 'no exception';
   note $error if $error;
   ok defined $dir && -d $dir, 'directory exists';
@@ -619,9 +619,9 @@ alien_subtest 'extract' => sub {
     my $file = path($dir)->child($name);
     ok -f $file, "$name exists";
   }
-  
+
   my $extract = $build->install_prop->{extract};
-  
+
   note "build.install.extract = $extract";
   ok( -d $extract, "build.install.extract is a directory" );
   ok( -f "$extract/configure", "has configure" );
@@ -633,25 +633,25 @@ subtest 'build' => sub {
   subtest 'plain' => sub {
     my $build = alienfile filename => 'corpus/blank/alienfile';
     my $meta = $build->meta;
-  
+
     my @data;
-  
+
     $meta->prop->{env}->{FOO1} = 'bar1';
     $build->install_prop->{env}->{FOO3} = 'bar3';
 
     local $ENV{FOO2} = 'bar2';
-  
+
     $meta->register_hook(
       probe => sub { 'share' },
     );
-  
+
     $meta->register_hook(
       extract => sub {
         path('file1')->spew('text1');
         path('file2')->spew('text2');
       },
     );
-  
+
     $meta->register_hook(
       build => sub {
         is $ENV{FOO1}, 'bar1';
@@ -660,15 +660,15 @@ subtest 'build' => sub {
         @data = (path('file1')->slurp, path('file2')->slurp);
       },
     );
-    
+
     my $gather = 0;
-    
+
     $meta->register_hook(
       gather_share => sub {
         $gather = 1;
       },
     );
-    
+
     my $tmp = Path::Tiny->tempdir;
     my $share = $tmp->child('blib/lib/auto/share/Alien-Foo/');
     $build->install_prop->{download} = path("corpus/dist/foo-1.00.tar")->absolute->stringify;
@@ -678,24 +678,24 @@ subtest 'build' => sub {
       $build->build;
       ();
     };
-  
+
     is(
       \@data,
       [ 'text1', 'text2'],
       'build',
     );
-    
+
     is $gather, 1, 'ran gather';
-    
+
     ok( -f $share->child('_alien/alien.json'), 'has alien.json');
     #ok( -f $share->child('_alienfile'), 'has alienfile');
   };
-  
+
   subtest 'destdir' => sub {
-  
+
     my $build = alienfile filename => 'corpus/blank/alienfile';
     my $meta = $build->meta;
-  
+
     $meta->register_hook(
       probe => sub { 'share' },
     );
@@ -706,7 +706,7 @@ subtest 'build' => sub {
         path('file2')->spew('text2');
       },
     );
-    
+
     $meta->register_hook(
       build => sub {
         my($build) = @_;
@@ -724,35 +724,35 @@ subtest 'build' => sub {
         $dir->child('lib/libfoo.a')->spew('foo lib');
       },
     );
-    
+
     my $gather = 0;
-    
+
     $meta->register_hook(
       gather_share => sub {
         $gather = 1;
       },
     );
-    
+
     my $tmp = Path::Tiny->tempdir;
-   
+
     my $share = $tmp->child('blib/lib/auto/share/Alien-Foo/');
 
     $build->meta_prop->{destdir}       = 1;
     $build->install_prop->{download}   = path("corpus/dist/foo-1.00.tar")->absolute->stringify;
     $build->set_prefix($tmp->child('usr/local')->stringify);
     $build->set_stage($share->stringify);
-    
+
     note capture_merged { $build->build };
-  
+
     ok(-d $share, "directory created" );
-    
+
     is $gather, 1, 'ran gather';
-    
+
     ok( -f $share->child('_alien/alien.json'), 'has alien.json');
     ok( -f $share->child('_alien/alienfile'), 'has alienfile');
-  
+
   };
-  
+
 };
 
 subtest 'checkpoint' => sub {
@@ -764,26 +764,26 @@ subtest 'checkpoint' => sub {
     use alienfile;
     meta_prop->{foo1} = 'bar1';
   });
-  
+
   subtest 'create checkpoint' => sub {
-  
+
     my $build = Alien::Build->load("$alienfile", root => "$root");
     is($build->meta_prop->{foo1}, 'bar1');
     $build->install_prop->{foo2} = 'bar2';
     $build->runtime_prop->{foo3} = 'bar3';
     $build->checkpoint;
-    
+
     ok( -r path($build->root, 'state.json') );
-  
+
   };
-  
+
   subtest 'resume checkpoint' => sub {
-  
+
     my $build = Alien::Build->resume("$alienfile", "$root");
     is($build->meta_prop->{foo1}, 'bar1');
     is($build->install_prop->{foo2}, 'bar2');
     is($build->runtime_prop->{foo3}, 'bar3');
-  
+
   };
 
 };
@@ -799,37 +799,37 @@ subtest 'patch' => sub {
     my $share = $tmp->child('blib/lib/auto/share/Alien-Foo/');
     $build->install_prop->{download} = path("corpus/dist/foo-1.00.tar")->absolute->stringify;
     $build->install_prop->{stage}    = $share->stringify;
-  
+
     $meta->register_hook(
       probe => sub { 'share' },
     );
-  
+
     $meta->register_hook(
       extract => sub {
         path('file1')->spew('The quick brown dog jumps over the lazy dog');
         path('file2')->spew('text2');
       },
     );
-  
+
     $meta->register_hook(
       patch => sub {
         # fix the saying.
         path('file1')->edit(sub { s/dog/fox/ });
       },
     );
-  
+
     $meta->register_hook(
       build => sub {
         my($build) = @_;
         path('file1')->copy(path($build->install_prop->{stage})->child('file3'));
       },
     );
-  
+
     note capture_merged {
       $build->build;
       ();
     };
-  
+
     my $file3 = path($build->install_prop->{stage})->child('file3');
     is(
       $file3->slurp,
@@ -846,32 +846,32 @@ subtest 'patch' => sub {
     my $share = $tmp->child('blib/lib/auto/share/Alien-Foo/');
     $build->install_prop->{download} = path("corpus/dist/foo-1.00.tar")->absolute->stringify;
     $build->install_prop->{stage}    = $share->stringify;
-  
+
     $meta->register_hook(
       probe => sub { 'share' },
     );
-  
+
     $meta->register_hook(
       extract => sub {
         path('file1')->spew('The quick brown dog jumps over the lazy dog');
         path('file2')->spew('The quick brown fox jumps over the lazy fox');
       },
     );
-  
+
     $meta->register_hook(
       patch => sub {
         # fix the saying.
         path('file1')->edit(sub { s/dog/fox/ });
       },
     );
-    
+
     $meta->register_hook(
       patch => sub {
         # fix the saying.
         path('file2')->edit(sub { s/fox$/dog/ });
       },
     );
-  
+
     $meta->register_hook(
       build => sub {
         my($build) = @_;
@@ -879,12 +879,12 @@ subtest 'patch' => sub {
         path('file2')->copy(path($build->install_prop->{stage})->child('file4'));
       },
     );
-  
+
     note capture_merged {
       $build->build;
       ();
     };
-  
+
     my $file3 = path($build->install_prop->{stage})->child('file3');
     is(
       $file3->slurp,
@@ -920,12 +920,12 @@ subtest 'preload' => sub {
       $meta->register_hook('preload2' => sub {});
     }
   }
-  
+
   local $ENV{ALIEN_BUILD_PRELOAD} = join ';', qw( Preload1 Preload1::Preload2 );
-  
+
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   ok( $meta->has_hook($_), "has hook $_" ) for qw( preload1 preload2 );
 
 };
@@ -939,52 +939,52 @@ subtest 'first probe returns share' => sub {
       probe sub { 'share' };
       probe sub { 'system' };
     };
-  
+
     note capture_merged {
       $build->probe;
     };
-  
+
     is( $build->install_type, 'system' );
   };
-  
+
   subtest 'command ok' => sub {
-  
+
     my $guard = system_fake
       'pkg-config' => sub { 0 }
     ;
-  
+
     my $build = alienfile q{
       use alienfile;
       probe [ [ 'pkg-config', '--exists', 'libfoo' ] ];
     };
-    
+
     note capture_merged {
       $build->probe;
       ();
     };
-    
+
     is($build->install_type, 'system');
-  
+
   };
 
   subtest 'command bad' => sub {
-  
+
     my $guard = system_fake
       'pkg-config' => sub { 1 }
     ;
-  
+
     my $build = alienfile q{
       use alienfile;
       probe [ [ 'pkg-config', '--exists', 'libfoo' ] ];
     };
-    
+
     note capture_merged {
       $build->probe;
       ();
     };
-    
+
     is($build->install_type, 'share');
-  
+
   };
 
 };
@@ -1005,7 +1005,7 @@ alien_subtest 'system' => sub {
   my $build = alienfile_ok q{
     use alienfile;
   };
-  
+
   $build->meta->interpolator->add_helper(
     foo => sub { '1234' },
   );
@@ -1013,16 +1013,16 @@ alien_subtest 'system' => sub {
   $build->meta->interpolator->add_helper(
     bar => sub { 'xor' },
   );
-  
+
   note scalar capture_merged { $build->system('frooble', '%{foo}') };
-  
+
   is(
     \@args,
     [ 'frooble', '1234' ],
   );
-  
+
   note scalar capture_merged { $build->system('%{bar}') };
-  
+
   is(
     \@args,
     [ 'xor' ],
@@ -1047,18 +1047,18 @@ subtest 'requires pulls helpers' => sub {
 alien_subtest 'around bug?' => sub {
 
   my $build = alienfile_ok q{
-  
+
     use alienfile;
-    
+
     meta->register_hook(
       foo => sub {
         my($build, $arg) = @_;
         return scalar reverse $arg;
       },
     );
-  
+
   };
-  
+
   is $build->_call_hook(foo => 'bar'), 'rab';
 
   $build->meta->around_hook(
@@ -1067,7 +1067,7 @@ alien_subtest 'around bug?' => sub {
       $orig->($build, "a${arg}b");
     },
   );
-  
+
   is $build->_call_hook(foo => 'bar'), 'braba';
 
   $build->meta->around_hook(
@@ -1076,7 +1076,7 @@ alien_subtest 'around bug?' => sub {
       $orig->($build, "|${arg}|");
     },
   );
-  
+
   is $build->_call_hook(foo => 'bar'), 'b|rab|a';
 
 };
@@ -1084,35 +1084,35 @@ alien_subtest 'around bug?' => sub {
 subtest 'requires of Alien::Build or Alien::Base' => sub {
 
   alien_subtest 'Alien::Build' => sub {
-  
+
     my $build = alienfile_ok q{
       use alienfile;
       requires 'Alien::Build' => 0;
     };
-    
+
     eval {
       $build->load_requires('configure');
       $build->load_requires('share');
     };
-    
+
     is $@, '';
-    
+
   };
 
   alien_subtest 'Alien::Base' => sub {
-  
+
     my $build = alienfile_ok q{
       use alienfile;
       requires 'Alien::Base' => 0;
     };
-    
+
     eval {
       $build->load_requires('configure');
       $build->load_requires('share');
     };
-    
+
     is $@, '';
-    
+
   };
 
 };
@@ -1122,7 +1122,7 @@ subtest 'out-of-source build' => sub {
   local $Alien::Build::VERSION = '1.08';
 
   alien_subtest 'basic' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
       use Path::Tiny qw( path );
@@ -1134,53 +1134,53 @@ subtest 'out-of-source build' => sub {
         build sub {
           my($build) = @_;
           my $extract = $build->install_prop->{extract};
-          
+
           die 'no extract'             unless -d $extract;
           die 'no $extract/configure'  unless -f "$extract/configure";
           die 'no $extract/foo.c'      unless -f "$extract/foo.c";
-          
+
           die 'found $build/configure' if -f 'configure';
           die 'found $build/foo.c'     if -f 'foo.c';
         };
       };
     };
-    
+
     alien_build_ok;
-  
+
   };
-  
+
   alien_subtest 'from bundled source' => sub {
 
     local $Alien::Build::Plugin::Fetch::LocalDir::VERSION = '1.07';
-  
+
     my $build = alienfile_ok q{
       use alienfile;
-      
+
       meta->prop->{out_of_source} = 1;
       meta->prop->{start_url}     = 'corpus/dist/foo-1.00';
-      
+
       share {
         plugin 'Fetch::LocalDir';
         plugin 'Extract' => 'd';
         build sub {
           my($build) = @_;
           my $extract = $build->install_prop->{extract};
-          
+
           die 'no extract'             unless -d $extract;
           die 'no $extract/configure'  unless -f "$extract/configure";
           die 'no $extract/foo.c'      unless -f "$extract/foo.c";
-          
+
           die 'found $build/configure' if -f 'configure';
           die 'found $build/foo.c'     if -f 'foo.c';
         };
       };
     };
-    
+
     alien_build_ok;
-    
+
     my $extract = $build->install_prop->{extract};
     note "extract = $extract";
-  
+
   };
 
 };
@@ -1189,16 +1189,16 @@ subtest 'test' => sub {
 
   local $Alien::Build::VERSION = $Alien::Build::VERSION;
   $Alien::Build::VERSION ||= '1.14';
-  
+
 
   alien_subtest 'good' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
       use Path::Tiny qw( path );
-      
+
       probe sub { 'share' };
-      
+
       share {
         download sub { path('file1')->touch };
         extract sub { path($_)->touch for qw( file2 file3 ) };
@@ -1212,9 +1212,9 @@ subtest 'test' => sub {
           die "hrm" unless $x eq 'content of file4';
         };
       };
-    
+
     };
-    
+
     alien_install_type_is 'share';
     alien_checkpoint_ok;
     alien_resume_ok;
@@ -1222,24 +1222,24 @@ subtest 'test' => sub {
     alien_checkpoint_ok;
 
     my $build = alien_resume_ok;
-    
+
     my($out, $error) = capture_merged {
       eval { $build->test };
       $@;
     };
     note $out;
-    
+
     is $error, '';
   };
-  
+
   alien_subtest 'bad' => sub {
 
     alienfile_ok q{
       use alienfile;
       use Path::Tiny qw( path );
-      
+
       probe sub { 'share' };
-      
+
       share {
         download sub { path('file1')->touch };
         extract sub { path($_)->touch for qw( file2 file3 ) };
@@ -1249,9 +1249,9 @@ subtest 'test' => sub {
           die "bogus!";
         };
       };
-    
+
     };
-    
+
     alien_install_type_is 'share';
     alien_checkpoint_ok;
     alien_resume_ok;
@@ -1265,18 +1265,18 @@ subtest 'test' => sub {
       $@;
     };
     note $out;
-    
+
     like $error, qr/bogus!/;
   };
-  
+
   alien_subtest 'ffi' => sub {
 
     alienfile_ok q{
       use alienfile;
       use Path::Tiny qw( path );
-      
+
       probe sub { 'share' };
-      
+
       share {
         download sub { path('file1')->touch };
         extract sub { path($_)->touch for qw( file2 file3 ) };
@@ -1285,23 +1285,23 @@ subtest 'test' => sub {
           path('file4')->spew('content of file4')
         };
         ffi {
-        
+
           build sub {
             path('file5')->spew('content of file5');
           };
-          
+
           test sub {
             die "bogus1" unless -f "file2";
             die "bogus2" unless -f "file3";
             my $x = path("file5")->slurp;
             die "bogus3" unless $x eq 'content of file5';
           };
-        
+
         };
       };
-    
+
     };
-    
+
     alien_install_type_is 'share';
     alien_checkpoint_ok;
     alien_resume_ok;
@@ -1315,7 +1315,7 @@ subtest 'test' => sub {
       $@;
     };
     note $out;
-    
+
     is $error, '';
   };
 
@@ -1324,9 +1324,9 @@ subtest 'test' => sub {
     alienfile_ok q{
       use alienfile;
       use Path::Tiny qw( path );
-      
+
       probe sub { 'share' };
-      
+
       share {
         download sub { path('file1')->touch };
         extract sub { path($_)->touch for qw( file2 file3 ) };
@@ -1335,20 +1335,20 @@ subtest 'test' => sub {
           path('file4')->spew('content of file4')
         };
         ffi {
-        
+
           build sub {
             path('file5')->spew('content of file5');
           };
-          
+
           test sub {
             die "bogus4";
           };
-        
+
         };
       };
-    
+
     };
-    
+
     alien_install_type_is 'share';
     alien_checkpoint_ok;
     alien_resume_ok;
@@ -1362,12 +1362,12 @@ subtest 'test' => sub {
       $@;
     };
     note $out;
-    
+
     like $error, qr/bogus4/;
   };
-  
+
   alien_subtest 'system good' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
       probe sub { 'system' };
@@ -1379,7 +1379,7 @@ subtest 'test' => sub {
         };
       };
     };
-    
+
     alien_install_type_is 'system';
     alien_checkpoint_ok;
     alien_resume_ok;
@@ -1392,13 +1392,13 @@ subtest 'test' => sub {
       $@;
     };
     note $out;
-    
+
     is $error, '';
-    
+
     is($build->install_prop->{foobar}, 'baz');
-    
+
   };
-  
+
   alien_subtest 'system bad' => sub {
 
     alienfile_ok q{
@@ -1413,7 +1413,7 @@ subtest 'test' => sub {
         };
       };
     };
-    
+
     alien_install_type_is 'system';
     alien_checkpoint_ok;
     alien_resume_ok;
@@ -1426,9 +1426,9 @@ subtest 'test' => sub {
       $@;
     };
     note $out;
-    
+
     like $error, qr/bogus16/;
-    
+
     is($build->install_prop->{foobar}, 'baz2');
   };
 
@@ -1437,15 +1437,15 @@ subtest 'test' => sub {
 alien_subtest 'pkg-config path during build' => sub {
 
   my $build = alienfile_ok q{
-  
+
     use alienfile;
     use Path::Tiny qw( path );
     use Env qw( @PKG_CONFIG_PATH );
-  
+
     probe sub { 'share' };
-  
+
     share {
-    
+
       requires 'Alien::libfoo2';
       download sub { path('file1')->touch };
       extract sub { path('file2')->touch };
@@ -1453,9 +1453,9 @@ alien_subtest 'pkg-config path during build' => sub {
         my($build) = @_;
         $build->runtime_prop->{my_pkg_config_path} = [@PKG_CONFIG_PATH];
       };
-    
+
     };
-  
+
   };
 
   alien_build_ok;
@@ -1476,7 +1476,7 @@ alien_subtest 'pkg-config path during build' => sub {
     },
     'has arch and arch-indy pkg-config paths',
   );
-  
+
 };
 
 done_testing;

--- a/t/alien_build_commandsequence.t
+++ b/t/alien_build_commandsequence.t
@@ -23,7 +23,7 @@ use Capture::Tiny qw( capture_merged );
     \@command_list;
   }
 
-  sub system_clear  
+  sub system_clear
   {
     @command_list = ();
   }
@@ -48,22 +48,22 @@ subtest 'apply requirements' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   my $intr = $meta->interpolator;
-  
+
   $intr->add_helper(foo => undef, Foo => '1.00');
   $intr->add_helper(bar => undef, Bar => '2.00');
   $intr->add_helper(baz => undef, Baz => '3.00');
-  
+
   my $seq = Alien::Build::CommandSequence->new(
     '%{foo}',
     [ '%{bar}' ],
     [ '%{baz}', '--version', sub {} ],
     sub {},
   );
-  
+
   $seq->apply_requirements($meta, 'share');
-  
+
   is(
     $build->requires('share'),
     hash {
@@ -72,7 +72,7 @@ subtest 'apply requirements' => sub {
       field Baz => '3.00';
     },
   );
-  
+
 };
 
 subtest 'execute' => sub {
@@ -83,22 +83,22 @@ subtest 'execute' => sub {
   $intr->add_helper(foo => sub { 'myfoo' });
 
   system_clear;
-  
+
   note capture_merged {
     Alien::Build::CommandSequence->new(
       '%{foo}',
       [ 'stuff', '%{foo}' ],
     )->execute($build);
   };
-  
+
   is(
     system_last,
     [ ['myfoo'], ['stuff','myfoo'] ],
     'plain',
   );
-  
+
   system_clear;
-  
+
   my $error;
   note capture_merged {
     eval {
@@ -109,25 +109,25 @@ subtest 'execute' => sub {
     };
     $error = $@;
   };
-  
+
   like $error, qr/command failed/;
-  
+
   system_clear;
-  
+
   system_hook stuff => sub {
     print "stuff output";
     print STDERR "stuff error";
   };
-  
+
 
   my @cap;
-  
+
   note capture_merged {
     Alien::Build::CommandSequence->new(
       [ 'stuff', '%{foo}', sub { @cap = @_ } ],
     )->execute($build);
   };
-  
+
   is(
     \@cap,
     array {
@@ -143,14 +143,14 @@ subtest 'execute' => sub {
       };
     },
   );
-  
+
   system_hook bogus => sub {
     print "bogus output";
     print STDERR "bogus error";
   };
-  
+
   @cap = ();
-  
+
   note capture_merged {
     Alien::Build::CommandSequence->new(
       [ 'bogus', '%{foo}', sub { @cap = @_ } ],
@@ -172,13 +172,13 @@ subtest 'execute' => sub {
       };
     },
   );
-  
+
   system_hook stuff2 => sub {
     print "single line\n";
     print STDERR "stuff error\n";
     print STDERR "stuff error\n";
   };
-  
+
   system_clear;
 
   note capture_merged {
@@ -186,7 +186,7 @@ subtest 'execute' => sub {
       [ 'stuff2', '%{foo}', \'%{alien.runtime.foo}' ],
     )->execute($build);
   };
-  
+
   is($build->runtime_prop->{foo}, 'single line');
 
   system_clear;

--- a/t/alien_build_commandsequence__cd.t
+++ b/t/alien_build_commandsequence__cd.t
@@ -23,11 +23,11 @@ subtest 'cd list' => sub {
     [ "cd", "$dir" ],
     sub { path('foo.txt')->spew('here') },
   );
-  
+
   note scalar capture_merged { $seq->execute($build) };
-  
+
   my $foo_txt = path($dir)->child('foo.txt');
-  
+
   is( -f $foo_txt, T(), "created file" );
   is( $foo_txt->slurp, "here", "content" );
 
@@ -42,17 +42,17 @@ subtest 'cd list' => sub {
   my $where;
 
   my $dir = path(tempdir( CLEANUP => 1 ))->child('foo')->canonpath;
-  
+
   my $seq = Alien::Build::CommandSequence->new(
     [ "%{make_path} $dir" ],
     "cd $dir",
     sub { path('foo.txt')->spew('here') },
   );
-  
+
   note scalar capture_merged { $seq->execute($build) };
-  
+
   my $foo_txt = path($dir)->child('foo.txt');
-  
+
   is( -f $foo_txt, T(), "created file" );
   is( $foo_txt->slurp, "here", "content" );
 
@@ -67,16 +67,16 @@ subtest 'cd list with code ref' => sub {
   my $where;
 
   my $dir = path(tempdir( CLEANUP => 1 ))->child('foo')->canonpath;
-  
+
   my $seq = Alien::Build::CommandSequence->new(
     [ "%{make_path} $dir" ],
     [ "cd", "$dir", sub { path('foo.txt')->spew('here') } ],
   );
-  
+
   note scalar capture_merged { $seq->execute($build) };
-  
+
   my $foo_txt = path($dir)->child('foo.txt');
-  
+
   is( -f $foo_txt, T(), "created file" );
   is( $foo_txt->slurp, "here", "content" );
 

--- a/t/alien_build_interpolate.t
+++ b/t/alien_build_interpolate.t
@@ -8,19 +8,19 @@ subtest 'basic usage' => sub {
   isa_ok $intr, 'Alien::Build::Interpolate';
 
   $intr->add_helper( foo => '"foo" . "foo"' );
-  
-  is( $intr->interpolate("bar%{foo}baz"), 'barfoofoobaz' );  
+
+  is( $intr->interpolate("bar%{foo}baz"), 'barfoofoobaz' );
   is( $intr->interpolate("bar%%baz"), 'bar%baz' );
-  
+
   $intr->add_helper( foo1 => sub { 'foo1' . 'foo1' } );
 
-  is( $intr->interpolate("bar%{foo1}baz"), 'barfoo1foo1baz' );  
+  is( $intr->interpolate("bar%{foo1}baz"), 'barfoo1foo1baz' );
 
   $intr->add_helper( 'foomake1', undef, 'Alien::foomake' => '0.22' );
   $intr->add_helper( 'foomake2', undef, 'Alien::foomake' => '0.24' );
   $intr->add_helper( 'foomake3', undef, 'Alien::foomake' => '0.29' );
   $intr->add_helper( 'foomake4', undef, 'Alien::foobogus' => '0'   );
-  
+
   is( $intr->interpolate("-%{foomake1}-"), '-foomake.exe-' );
   is( $intr->interpolate("-%{foomake2}-"), '-foomake.exe-' );
 
@@ -31,10 +31,10 @@ subtest 'basic usage' => sub {
   eval { $intr->interpolate("-%{foomake4}-") };
   isnt( $@, '', "error!");
   note $@;
-  
+
   $intr->add_helper( bar => undef, 'XYZ::ABC' => '1.234' );
   $intr->add_helper( baz => undef, 'ABC::XYZ' => '4.321' );
-  
+
   is( [$intr->requires("%{bar}%{baz}")], [ 'XYZ::ABC' => '1.234', 'ABC::XYZ' => '4.321' ], 'requires' );
 
   eval { $intr->add_helper( foo1 => sub { } ) };
@@ -55,15 +55,15 @@ subtest 'clone' => sub {
   isa_ok $intr1, 'Alien::Build::Interpolate';
 
   $intr1->add_helper( foo => sub { 100 } );
-  
+
   my $intr2 = $intr1->clone;
-  
+
   $intr2->add_helper( bar => sub { 200 } );
-  
+
   is( $intr1->interpolate('%{foo}'), 100);
   is( $intr2->interpolate('%{foo}'), 100);
   is( $intr2->interpolate('%{bar}'), 200);
-  
+
   my $ret = eval { $intr1->interpolate('%{bar}') };
   my $error = $@;
   like $error, qr/no helper defined for bar/;
@@ -82,14 +82,14 @@ subtest 'property' => sub {
   eval {
     $intr->interpolate("'%{foo.bar}'", { foo => { bar1 => 'baz' } }),
   };
-  
+
   like $@, qr/No property foo.bar is defined/;
-  
+
   is(
     $intr->interpolate("%{foo.bar.baz}", { foo => { bar => { baz => 'starscream' } } }),
     'starscream',
   );
-  
+
 };
 
 subtest 'property, default to alien' => sub {
@@ -116,10 +116,10 @@ subtest 'has_helper' => sub {
 
   is(ref($foo), 'CODE');
   is(ref($bar), 'CODE');
-  
+
   is($foo->(), 'foo3');
   is($bar->(), 'bar7');
-  
+
 };
 
 done_testing;

--- a/t/alien_build_interpolate_default.t
+++ b/t/alien_build_interpolate_default.t
@@ -22,9 +22,9 @@ subtest 'basic usage' => sub {
 subtest 'cwd' => sub {
 
   my $intr = Alien::Build::Interpolate::Default->new;
-  
+
   my $val = $intr->interpolate('%{cwd}');
-  
+
   ok $val, "%{cwd} is okay";
   note "val = $val";
 
@@ -35,11 +35,11 @@ subtest 'mkdir_deep' => sub {
   local $Alien::Build::VERSION = '1.04';
 
   my $intr = Alien::Build::Interpolate::Default->new;
-  
+
   my $val = $intr->interpolate('%{mkdir_deep} foo');
-  
+
   my $expected = $^O eq 'MSWin32' ? 'md foo' : 'mkdir -p foo';
-  
+
   is($val, $expected);
 };
 
@@ -48,11 +48,11 @@ subtest 'make_path' => sub {
   local $Alien::Build::VERSION = '1.05';
 
   my $intr = Alien::Build::Interpolate::Default->new;
-  
+
   my $val = $intr->interpolate('%{make_path} foo');
-  
+
   my $expected = $^O eq 'MSWin32' ? 'md foo' : 'mkdir -p foo';
-  
+
   is($val, $expected);
 };
 

--- a/t/alien_build_meta.t
+++ b/t/alien_build_meta.t
@@ -6,7 +6,7 @@ subtest 'basic' => sub {
 
   my $build = alienfile_ok qq{ use alienfile };
   my $meta = $build->meta;
-  
+
   isa_ok( $build->meta, 'Alien::Build::Meta' );
 
 };

--- a/t/alien_build_mm.t
+++ b/t/alien_build_mm.t
@@ -1,6 +1,6 @@
 use Test2::V0 -no_srand => 1;
 use Test::Alien::Build ();
-use Alien::Build::MM qw( cmd ); 
+use Alien::Build::MM qw( cmd );
 use File::chdir;
 use File::Temp qw( tempdir );
 use Path::Tiny qw( path );
@@ -28,27 +28,27 @@ subtest 'basic' => sub {
     probe sub {
       $ENV{ALIEN_INSTALL_TYPE};
     };
-    
+
     configure {
       requires 'Config::Foo' => '1.234',
       requires 'Config::Bar' => 0,
     };
-    
+
     share {
       requires 'Share::Foo' => '4.567',
     };
-    
+
     sys {
       requires 'Sys::Foo' => '9.99',
     };
   };
-  
+
   subtest 'system' => sub {
 
     local $ENV{ALIEN_INSTALL_TYPE} = 'system';
 
     my $abmm = Alien::Build::MM->new;
-  
+
     isa_ok $abmm, 'Alien::Build::MM';
     isa_ok $abmm->build, 'Alien::Build';
 
@@ -67,7 +67,7 @@ subtest 'basic' => sub {
 
     is(path($abmm->build->install_prop->{stage})->basename, 'Alien-Foo', 'stage dir');
     note "stage = @{[ $abmm->build->install_prop->{stage} ]}";
-  
+
     is(
       \%args,
       hash {
@@ -89,9 +89,9 @@ subtest 'basic' => sub {
         etc;
       },
     );
-  
+
     undef $abmm;
-  
+
     ok( -d '_alien', "left alien directory" );
     ok( -f '_alien/state.json', "left alien.json file" );
 
@@ -102,7 +102,7 @@ subtest 'basic' => sub {
     local $ENV{ALIEN_INSTALL_TYPE} = 'share';
 
     my $abmm = Alien::Build::MM->new;
-  
+
     isa_ok $abmm, 'Alien::Build::MM';
     isa_ok $abmm->build, 'Alien::Build';
 
@@ -140,9 +140,9 @@ subtest 'basic' => sub {
         etc;
       },
     );
-  
+
   };
-  
+
 };
 
 subtest 'mm_postamble' => sub {
@@ -161,29 +161,29 @@ subtest 'mm_postamble' => sub {
   );
 
   my $postamble = $abmm->mm_postamble;
-  
+
   ok $postamble, 'returned a true value';
   note $postamble;
 
 };
 
 subtest 'set_prefix' => sub {
-  
+
   foreach my $type (qw( perl site vendor ))
   {
 
     subtest "type = $type" => sub {
-  
+
       local $CWD = tempdir( CLEANUP => 1 );
 
       alienfile q{
         use alienfile;
         probe sub { 'share' };
       };
-  
+
       my @dirs = map { path($CWD)->child('foo')->child($_) } qw( perl site vendor );
       $_->mkpath for @dirs;
- 
+
       do {
         my $abmm = Alien::Build::MM->new;
         $abmm->mm_args(
@@ -195,15 +195,15 @@ subtest 'set_prefix' => sub {
         local @ARGV = ($type, @dirs);
         prefix();
       };
-  
+
       ok( -f '_alien/mm/prefix', 'touched prefix' );
-      
+
       my $build = Alien::Build->resume('alienfile', '_alien');
       my $prefix = path($build->runtime_prop->{prefix})->relative($CWD)->stringify;
       is $prefix, "foo/$type/auto/share/dist/Alien-Foo", "correct path";
     };
   }
-  
+
 };
 
 subtest 'download + build' => sub {
@@ -243,18 +243,18 @@ subtest 'download + build' => sub {
   $abmm->mm_args(
     DISTNAME => 'Alien-Foo',
   );
-  
+
   note capture_merged {
     local @ARGV = ('perl', map { ($_,$_,$_) } tempdir( CLEANUP => 1 ));
     prefix();
   };
-  
+
   note capture_merged {
     local @ARGV = ();
     download();
   };
 
-  ok( -f '_alien/mm/download', 'touched download' );  
+  ok( -f '_alien/mm/download', 'touched download' );
   is $main::call_download, 1, 'download';
 
   note capture_merged {
@@ -262,7 +262,7 @@ subtest 'download + build' => sub {
     build();
   };
 
-  ok( -f '_alien/mm/build', 'touched build' );  
+  ok( -f '_alien/mm/build', 'touched build' );
   is $main::call_build, 1, 'build';
 
 };
@@ -270,19 +270,19 @@ subtest 'download + build' => sub {
 subtest 'patch' => sub {
 
   local $CWD = tempdir( CLEANUP => 1 );
-  
+
   alienfile q{
     use alienfile;
   };
-  
+
   path('patch')->mkpath;
   path('patch/foo.txt')->touch;
-  
+
   my $abmm = Alien::Build::MM->new;
-  
+
   ok( $abmm->build->install_prop->{patch}, 'patch is defined' );
-  
-  ok( -f path($abmm->build->install_prop->{patch})->child('foo.txt'), 'got the correct directory' );  
+
+  ok( -f path($abmm->build->install_prop->{patch})->child('foo.txt'), 'got the correct directory' );
 };
 
 done_testing;

--- a/t/alien_build_plugin.t
+++ b/t/alien_build_plugin.t
@@ -15,14 +15,14 @@ subtest 'properties' => sub {
 
   subtest 'defaults' => sub {
 
-    my $plugin = Alien::Build::Plugin::RogerRamjet->new;  
+    my $plugin = Alien::Build::Plugin::RogerRamjet->new;
     is $plugin->foo, 22;
     is $plugin->bar, 'something generated';
-  
+
   };
-  
+
   subtest 'override' => sub {
-  
+
     my $plugin = Alien::Build::Plugin::RogerRamjet->new(
       foo => 42,
       bar => 'anything else',
@@ -30,16 +30,16 @@ subtest 'properties' => sub {
 
     is $plugin->foo, 42;
     is $plugin->bar, 'anything else';
-  
+
   };
-  
+
   subtest 'set' => sub {
-  
+
     my $plugin = Alien::Build::Plugin::RogerRamjet->new;
-    
+
     $plugin->foo(92);
     $plugin->bar('string');
-  
+
     is $plugin->foo, 92;
     is $plugin->bar, 'string';
 
@@ -53,16 +53,16 @@ subtest 'subplugin' => sub {
     package
       Alien::Build::Plugin::Foo::Bar;
     use Alien::Build::Plugin;
-    
+
     has foo => undef;
     has bar => 2;
-    
+
     sub init
     {
       my($self,$meta) = @_;
     }
   }
-  
+
   my $plugin1 = Alien::Build::Plugin::RogerRamjet->new;
   my $plugin2;
   is(

--- a/t/alien_build_plugin_build_autoconf.t
+++ b/t/alien_build_plugin_build_autoconf.t
@@ -13,14 +13,14 @@ subtest 'basic' => sub {
 
   my $build = alienfile_ok q{ use alienfile };
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
-  
+
   my $configure = $meta->interpolator->interpolate('%{configure}');
   isnt $configure, '', "\%{configure} = $configure";
   like $configure, qr{configure};
   like $configure, qr{--with-pic};
-  
+
   is($build->meta_prop->{destdir}, 1);
   is($meta->prop->{destdir}, 1);
 };
@@ -30,10 +30,10 @@ subtest 'turn off --with-pic' => sub {
   my $plugin = Alien::Build::Plugin::Build::Autoconf->new( with_pic => 0 );
 
   is( $plugin->with_pic, 0 );
-  
+
   my $build = alienfile_ok q{ use alienfile };
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
 
   my $configure = $meta->interpolator->interpolate('%{configure}');
@@ -50,7 +50,7 @@ subtest 'out-of-source' => sub {
     use alienfile;
     use Alien::Build::Util qw( _dump );
     use Path::Tiny qw( path );
-    
+
     share {
       meta->prop->{out_of_source} = 1;
       plugin 'Download::Foo';
@@ -65,14 +65,14 @@ subtest 'out-of-source' => sub {
         my $prefix = $build->install_prop->{prefix};
         $prefix =~ s{^([a-z]):/}{$1/}i if $^O eq 'MSWin32';
 
-        $build->log("prefix = $prefix");        
+        $build->log("prefix = $prefix");
         my $file2 = path($ENV{DESTDIR})->child($prefix)->child('file2');
         $file2->parent->mkpath;
         $file2->touch;
       };
     };
   };
-  
+
   $build->load_requires('share');
 
   note _dump($build->install_prop);
@@ -82,9 +82,9 @@ subtest 'out-of-source' => sub {
     note "%{configure} = $configure";
     ok 1;
   };
-  
+
   alien_build_ok;
-  
+
   note _dump($build->install_prop);
 
   subtest 'after build' => sub {
@@ -109,7 +109,7 @@ done_testing;
 {
   package
     Alien::MSYS;
-    
+
   use File::Temp qw( tempdir );
 
   BEGIN {
@@ -127,5 +127,5 @@ done_testing;
     }
     $path;
   }
-  
+
 }

--- a/t/alien_build_plugin_build_cmake.t
+++ b/t/alien_build_plugin_build_cmake.t
@@ -26,13 +26,13 @@ foreach my $type (qw( basic out-of-source ))
       meta->prop->{start_url} = path('corpus/cmake-libpalindrome')->absolute->stringify;
 
       probe sub { 'share' };
-  
+
       share {
         plugin 'Fetch::LocalDir';
         plugin 'Extract' => 'd';
         plugin 'Build::CMake';
         plugin 'Gather::IsolateDynamic';
-      
+
         gather sub {
           my($build) = @_;
           my $prefix = $build->runtime_prop->{prefix};
@@ -50,7 +50,7 @@ foreach my $type (qw( basic out-of-source ))
         };
       };
     };
-    
+
     if($type eq 'out-of-source')
     {
       $build->meta->prop->{out_of_source} = 1;
@@ -83,18 +83,18 @@ foreach my $type (qw( basic out-of-source ))
         diag `ls -lR $tmp`;
       }
     }
-  
+
     alien_ok $alien;
 
     note 'cflags = ', $alien->cflags;
     note 'libs   = ', $alien->libs;
-  
+
     xs_ok { xs => $xs, verbose => 1 }, with_subtest {
       my($mod) = @_;
       is($mod->is_palindrome("Something that is not a palindrome"), 0);
       is($mod->is_palindrome("Was it a car or a cat I saw?"), 1);
     };
-  
+
     run_ok(['palx', 'Something that is not a palindrome'])
       ->note
       ->exit_is(2);
@@ -106,7 +106,7 @@ foreach my $type (qw( basic out-of-source ))
     run_ok(['palx', 'racecar'])
       ->note
       ->success;
-  
+
   };
 };
 

--- a/t/alien_build_plugin_build_make.t
+++ b/t/alien_build_plugin_build_make.t
@@ -14,7 +14,7 @@ subtest 'compile' => sub {
 
       if($type =~ /nmake|dmake/)
       {
-      
+
         is(
           $build->meta->interpolator->interpolate('%{make}'),
           $type,
@@ -31,9 +31,9 @@ subtest 'gmake' => sub {
     use alienfile;
     use Path::Tiny qw( path );
     plugin 'Build::Make' => 'gmake';
-    
+
     probe sub { 'share' };
-    
+
     share {
       download sub { path('file1')->touch };
       extract sub {
@@ -47,7 +47,7 @@ subtest 'gmake' => sub {
           "install:foo.exe\n",
           "\t$^X install.pl foo.exe \$(PREFIX)/bin/foo.exe\n",
         );
-        
+
         path('build.pl')->spew("#!$^X\n", q{
           use strict;
           use warnings;
@@ -55,7 +55,7 @@ subtest 'gmake' => sub {
           my($from, $to) = map { path($_) } @ARGV;
           $to->spew('[' . $from->slurp . ']');
         });
-        
+
         path('install.pl')->spew("#!$^X\n", q{
           use strict;
           use warnings;
@@ -65,7 +65,7 @@ subtest 'gmake' => sub {
           $from->copy($to);
           print "copy $from $to\n";
         });
-        
+
         path('foo.c')->spew(
           "something",
         );
@@ -77,7 +77,7 @@ subtest 'gmake' => sub {
       ];
     };
   };
-  
+
   eval {
     $Alien::Build::Plugin::Build::Make::VERSION = '0.01';
     $build->load_requires('configure');
@@ -88,7 +88,7 @@ subtest 'gmake' => sub {
   note "make = @{[ $build->meta->interpolator->interpolate('%{make}') ]}";
 
   my $alien = alien_build_ok;
-  
+
   my $foo_exe = path($alien->bin_dir)->child('foo.exe');
   note "foo_exe = $foo_exe";
   note "content = ", $foo_exe->slurp;

--- a/t/alien_build_plugin_build_msys.t
+++ b/t/alien_build_plugin_build_msys.t
@@ -21,10 +21,10 @@ done_testing;
 {
   package
     Alien::MSYS;
-    
+
   BEGIN {
     our $VERSION = '0.07';
     $INC{'Alien/MSYS.pm'} = __FILE__;
   }
-  
+
 }

--- a/t/alien_build_plugin_build_searchdep.t
+++ b/t/alien_build_plugin_build_searchdep.t
@@ -17,17 +17,17 @@ subtest basic => sub {
   delete $ENV{$_} for qw( CFLAGS CXXFLAGS LDFLAGS );
 
   my $build = alienfile q{
-  
+
     use alienfile;
-    
+
     share {
-    
+
       plugin 'Download::Foo';
-    
+
       plugin 'Build::SearchDep' => (
         aliens => 'Alien::libfoo2',
       );
-      
+
       build sub {
         my($build) = @_;
         for(qw( CFLAGS CXXFLAGS LDFLAGS ))
@@ -37,18 +37,18 @@ subtest basic => sub {
           $build->runtime_prop->{"my_$_"} = $ENV{$_};
         }
       };
-      
+
       gather sub {
         my($build) = @_;
-        
+
         $build->runtime_prop->{cflags} = '-core-cflag';
         $build->runtime_prop->{cflags_static} = '-core-cflag-static';
         $build->runtime_prop->{libs} = '-core-flag';
         $build->runtime_prop->{libs_static} = '-core-flag-static';
       };
-    
+
     };
-  
+
   };
 
   ok $build->requires('configure')->{'Alien::Build::Plugin::Build::SearchDep'}, 'set configure require for self';
@@ -66,11 +66,11 @@ subtest basic => sub {
 
   is($build->runtime_prop->{libs}, "-L$corpus/lib/auto/share/dist/Alien-libfoo2/lib -core-flag", 'libs');
   is($build->runtime_prop->{libs_static}, "-L$corpus/lib/auto/share/dist/Alien-libfoo2/lib -core-flag-static", 'libs_static');
-  
+
   is($build->runtime_prop->{my_CFLAGS}, "-I$corpus/lib/auto/share/dist/Alien-libfoo2/include", 'my_CFLAGS');
   is($build->runtime_prop->{my_CXXFLAGS}, "-I$corpus/lib/auto/share/dist/Alien-libfoo2/include", 'my_CXXFLAGS');
   is($build->runtime_prop->{my_LDFLAGS}, "-L$corpus/lib/auto/share/dist/Alien-libfoo2/lib", 'my_LDFLAGS');
-  
+
 };
 
 
@@ -79,31 +79,31 @@ subtest public_I => sub {
   delete $ENV{$_} for qw( CFLAGS CXXFLAGS LDFLAGS );
 
   my $build = alienfile q{
-  
+
     use alienfile;
-    
+
     share {
-    
+
       plugin 'Download::Foo';
-    
+
       plugin 'Build::SearchDep' => (
         aliens => 'Alien::libfoo2',
         public_I => 1,
       );
-      
+
       build sub {};
-      
+
       gather sub {
         my($build) = @_;
-        
+
         $build->runtime_prop->{cflags} = '-core-cflag';
         $build->runtime_prop->{cflags_static} = '-core-cflag-static';
         $build->runtime_prop->{libs} = '-core-flag';
         $build->runtime_prop->{libs_static} = '-core-flag-static';
       };
-    
+
     };
-  
+
   };
 
   note scalar capture_merged {
@@ -124,32 +124,32 @@ subtest public_l => sub {
   delete $ENV{$_} for qw( CFLAGS CXXFLAGS LDFLAGS );
 
   my $build = alienfile q{
-  
+
     use alienfile;
-    
+
     share {
-    
+
       plugin 'Download::Foo';
-    
+
       plugin 'Build::SearchDep' => (
         aliens => 'Alien::libfoo2',
         public_l => 1,
       );
-      
+
       build sub {
       };
-      
+
       gather sub {
         my($build) = @_;
-        
+
         $build->runtime_prop->{cflags} = '-core-cflag';
         $build->runtime_prop->{cflags_static} = '-core-cflag-static';
         $build->runtime_prop->{libs} = '-core-flag';
         $build->runtime_prop->{libs_static} = '-core-flag-static';
       };
-    
+
     };
-  
+
   };
 
   note scalar capture_merged {
@@ -169,44 +169,44 @@ subtest public_l => sub {
 subtest list => sub {
 
   my $build = alienfile q{
-  
+
     use alienfile;
-    
+
     plugin 'Build::SearchDep' => (
       aliens => [ 'Alien::libfoo1', 'Alien::libfoo2' ],
     );
-    
+
     share {
     };
-  
+
   };
 
   ok $build->requires('configure')->{'Alien::Build::Plugin::Build::SearchDep'}, 'set configure require for self';
   ok $build->requires('share')->{'Env::ShellWords'}, 'set share require for Env::ShellWords';
   is $build->requires('share')->{'Alien::libfoo1'}, 0, 'set share require for Alien::libfoo1';
   is $build->requires('share')->{'Alien::libfoo2'}, 0, 'set share require for Alien::libfoo2';
-  
+
 };
 
 subtest hash => sub {
 
   my $build = alienfile q{
-  
+
     use alienfile;
-    
+
     plugin 'Build::SearchDep' => (
       aliens => { 'Alien::libfoo2' => '0.01'},
     );
-    
+
     share {
     };
-  
+
   };
 
   ok $build->requires('configure')->{'Alien::Build::Plugin::Build::SearchDep'}, 'set configure require for self';
   ok $build->requires('share')->{'Env::ShellWords'}, 'set share require for Env::ShellWords';
   is $build->requires('share')->{'Alien::libfoo2'}, '0.01', 'set share require for Alien::libfoo2';
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_core_ffi.t
+++ b/t/alien_build_plugin_core_ffi.t
@@ -11,11 +11,11 @@ subtest basic => sub {
     use Alien::Build::Util qw( _destdir_prefix );
 
     probe sub { 'share' };
-    
+
     meta_prop->{destdir} = 1;
-    
+
     share {
-    
+
       download sub { path('foo-1.00.tar.gz')->touch };
       extract  sub { path($_)->touch for qw( file1 file2 ) };
       build sub {
@@ -26,10 +26,10 @@ subtest basic => sub {
         $dir->child('lib', 'libfoo.a')->touch;
       };
 
-      ffi { 
+      ffi {
 
         patch sub { shift->{runtime_prop}->{my_did_patch_ffi} = 1 };
-      
+
         build sub {
           my($build) = @_;
           print "in build_ffi DESTDIR = $ENV{DESTDIR}\n";
@@ -40,14 +40,14 @@ subtest basic => sub {
           $dir->child('lib', 'libgarbage.a')->touch;
           $build->{runtime_prop}->{my_did_build_ffi} = 1;
         };
-      
+
         gather sub {
           my($build) = @_;
           print "in gather_ffi\n";
           $build->{runtime_prop}->{my_did_gather_ffi} = 1;
         };
       };
-    
+
     };
   };
 
@@ -62,11 +62,11 @@ subtest basic => sub {
   ok($build->{runtime_prop}->{my_did_gather_ffi}, 'did gather_ffi');
 
   my $stage = $build->install_prop->{stage};
-  
+
   ok(-f "$stage/lib/libfoo.a", 'has static lib');
   ok(-f "$stage/dynamic/libfoo.so", 'has dynamic lib');
   ok(!-f "$stage/lib/libgarbage.a", "filter out garbage");
-  
+
 };
 
 subtest deprecated => sub {
@@ -77,11 +77,11 @@ subtest deprecated => sub {
     use Alien::Build::Util qw( _destdir_prefix );
 
     probe sub { 'share' };
-    
+
     meta_prop->{destdir} = 1;
-    
+
     share {
-    
+
       download sub { path('foo-1.00.tar.gz')->touch };
       extract  sub { path($_)->touch for qw( file1 file2 ) };
       build sub {
@@ -93,7 +93,7 @@ subtest deprecated => sub {
       };
 
       patch_ffi sub { shift->{runtime_prop}->{my_did_patch_ffi} = 1 };
-      
+
       build_ffi sub {
         my($build) = @_;
         print "in build_ffi DESTDIR = $ENV{DESTDIR}\n";
@@ -104,16 +104,16 @@ subtest deprecated => sub {
         $dir->child('lib', 'libgarbage.a')->touch;
         $build->{runtime_prop}->{my_did_build_ffi} = 1;
       };
-      
+
       gather_ffi sub {
         my($build) = @_;
         print "in gather_ffi\n";
         $build->{runtime_prop}->{my_did_gather_ffi} = 1;
       };
-    
+
     };
   } };
-  
+
   note "build warnings: $out";
 
   note scalar capture_merged {
@@ -127,11 +127,11 @@ subtest deprecated => sub {
   ok($build->{runtime_prop}->{my_did_gather_ffi}, 'did gather_ffi');
 
   my $stage = $build->install_prop->{stage};
-  
+
   ok(-f "$stage/lib/libfoo.a", 'has static lib');
   ok(-f "$stage/dynamic/libfoo.so", 'has dynamic lib');
   ok(!-f "$stage/lib/libgarbage.a", "filter out garbage");
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_core_gather.t
+++ b/t/alien_build_plugin_core_gather.t
@@ -31,7 +31,7 @@ subtest 'destdir filter' => sub {
   };
 
   note capture_merged {
-    eval { 
+    eval {
       $build->probe;
       $build->download;
       $build->build;
@@ -43,7 +43,7 @@ subtest 'destdir filter' => sub {
   note _dump $build->install_prop;
 
   my $stage = path($build->install_prop->{stage});
-  
+
   ok( -f $stage->child('bin/foo.exe'), 'bin/foo.exe' );
   ok( -f $stage->child('lib/libfoo.a'), 'lib/libfoo.a' );
   ok( !-f $stage->child('etc/foorc'), 'etc/foorc' );
@@ -75,7 +75,7 @@ subtest 'patch' => sub {
 
   my $error = $@;
   note capture_merged {
-    eval { 
+    eval {
       $build->probe;
       $build->download;
       $build->build;
@@ -84,12 +84,12 @@ subtest 'patch' => sub {
     warn $error if $error;
     ();
   };
-  
+
   is $error, '';
-  
+
   note _dump $build->install_prop;
 
-  ok( -f $stage->child('_alien/patch/foo.diff') );  
+  ok( -f $stage->child('_alien/patch/foo.diff') );
 };
 
 subtest 'pkg-config path during gather' => sub {
@@ -117,7 +117,7 @@ subtest 'pkg-config path during gather' => sub {
       };
     };
   };
-  
+
   alien_build_ok;
 
   is(
@@ -136,7 +136,7 @@ subtest 'pkg-config path during gather' => sub {
     },
     'has arch and arch-indy pkg-config paths',
   );
-  
+
 
 };
 

--- a/t/alien_build_plugin_core_legacy.t
+++ b/t/alien_build_plugin_core_legacy.t
@@ -22,18 +22,18 @@ subtest 'basic' => sub {
       };
     };
   };
-  
+
   capture_merged {
     $build->probe;
     $build->download;
     $build->build;
   };
-  
+
   is( $build->runtime_prop->{cflags},        '-DFOO=1', 'cflags'        );
   is( $build->runtime_prop->{libs},          '-lfoo',   'libs'          );
   is( $build->runtime_prop->{cflags_static}, '-DFOO=1', 'cflags_static' );
   is( $build->runtime_prop->{libs_static},   '-lfoo',   'libs_static'   );
-  
+
   is(
     $build->runtime_prop->{legacy},
     hash {

--- a/t/alien_build_plugin_core_override.t
+++ b/t/alien_build_plugin_core_override.t
@@ -7,101 +7,101 @@ subtest 'basic' => sub {
   subtest 'default' => sub {
 
     local $ENV{ALIEN_INSTALL_TYPE} = 'default';
-    
+
     subtest 'system' => sub {
-    
+
       alienfile_ok q{
         use alienfile;
         probe sub { 'system' };
       };
-      
+
       alien_install_type_is 'system';
-    
+
     };
-    
+
     subtest 'share' => sub {
-    
+
       alienfile_ok q{
         use alienfile;
         probe sub { 'share' };
       };
-      
+
       alien_install_type_is 'share';
-    
+
     };
-    
+
     subtest 'die' => sub {
-    
+
       alienfile_ok q{
         use alienfile;
         probe sub { die };
       };
-      
+
       alien_install_type_is 'share';
-    
+
     };
-  
+
   };
 
   subtest 'share' => sub {
-    
+
     local $ENV{ALIEN_INSTALL_TYPE} = 'share';
 
     alienfile_ok q{
       use alienfile;
       probe sub { die "should not get into here!" };
     };
-    
+
     alien_install_type_is 'share';
   };
-    
+
   subtest 'system' => sub {
-    
+
     local $ENV{ALIEN_INSTALL_TYPE} = 'system';
-    
+
     subtest 'probe okay' => sub {
 
       alienfile_ok q{
         use alienfile;
         probe sub { 'system' };
-      };      
-      
+      };
+
       alien_install_type_is 'system';
     };
-      
+
     subtest 'probe share' => sub {
 
       my $build = alienfile_ok q{
         use alienfile;
         probe sub { 'share' };
-      };      
+      };
 
       eval { $build->probe };
       my $error = $@;
       like $error, qr/requested system install not available/;
-      
+
     };
-      
+
     subtest 'probe exception' => sub {
 
       my $build = alienfile_ok q{
         use alienfile;
         probe sub { die 'oops!' };
-      };      
+      };
 
       eval { $build->probe };
       my $error = $@;
       like $error, qr/oops!/;
-      
+
     };
-    
+
   };
 };
 
 subtest 'override the override' => sub {
 
   subtest 'syste, share' => sub {
-  
+
     local $ENV{ALIEN_INSTALL_TYPE} = 'system';
 
     alienfile_ok q{
@@ -109,11 +109,11 @@ subtest 'override the override' => sub {
       meta->register_hook(override => sub { 'share' });
       probe sub { 'system' };
     };
-    
+
     alien_install_type_is 'share';
-     
+
   };
-  
+
   subtest 'share, system' => sub {
 
     local $ENV{ALIEN_INSTALL_TYPE} = 'share';

--- a/t/alien_build_plugin_core_setup.t
+++ b/t/alien_build_plugin_core_setup.t
@@ -8,7 +8,7 @@ subtest 'compiler type' => sub {
     use alienfile;
   };
 
-  ok( $build->meta_prop->{platform}->{compiler_type}, 'has a compiler type' );  
+  ok( $build->meta_prop->{platform}->{compiler_type}, 'has a compiler type' );
   note "compiler type = @{[ $build->meta_prop->{platform}->{compiler_type} ]}";
 };
 

--- a/t/alien_build_plugin_core_tail.t
+++ b/t/alien_build_plugin_core_tail.t
@@ -15,8 +15,8 @@ subtest 'out-of-source build' => sub {
       field 'Alien::Build' => '1.08';
       etc;
     },
-  );  
-  
+  );
+
 
 };
 

--- a/t/alien_build_plugin_decode_dirlisting.t
+++ b/t/alien_build_plugin_decode_dirlisting.t
@@ -10,9 +10,9 @@ subtest 'updates requires' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
-  
+
   is( $build->requires('share')->{'File::Listing'}, 0 );
   is( $build->requires('share')->{'URI'}, 0 );
 
@@ -26,7 +26,7 @@ subtest 'decode' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-   
+
   $plugin->init($meta);
 
   eval { $build->load_requires('share') };

--- a/t/alien_build_plugin_decode_dirlistingftpcopy.t
+++ b/t/alien_build_plugin_decode_dirlistingftpcopy.t
@@ -10,9 +10,9 @@ subtest 'updates requires' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
-  
+
   is( $build->requires('share')->{'File::Listing'}, 0 );
   is( $build->requires('share')->{'URI'}, 0 );
 
@@ -26,7 +26,7 @@ subtest 'decode' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
 
   eval { $build->load_requires('share') };

--- a/t/alien_build_plugin_decode_html.t
+++ b/t/alien_build_plugin_decode_html.t
@@ -10,9 +10,9 @@ subtest 'updates requires' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
-  
+
   is( $build->requires('share')->{'HTML::LinkExtor'}, 0 );
   is( $build->requires('share')->{'URI'}, 0 );
 
@@ -26,7 +26,7 @@ subtest 'decode' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
 
   eval { $build->load_requires('share') };

--- a/t/alien_build_plugin_download_negotiate.t
+++ b/t/alien_build_plugin_download_negotiate.t
@@ -12,71 +12,71 @@ subtest 'pick fetch' => sub {
   local %ENV = %ENV;
 
   subtest 'http' => sub {
-  
+
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('http://mytest.test/');
-    
+
     is([$plugin->pick], ['Fetch::HTTPTiny','Decode::HTML']);
     is($plugin->scheme, 'http');
-  
+
   };
-  
+
   subtest 'https' => sub {
-  
+
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('https://mytest.test/');
-    
+
     is([$plugin->pick], ['Fetch::HTTPTiny','Decode::HTML']);
     is($plugin->scheme, 'https');
-  
+
   };
-  
+
   subtest 'ftp direct' => sub {
-  
+
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('ftp://mytest.test/');
-    
+
     is([$plugin->pick], ['Fetch::NetFTP']);
     is($plugin->scheme, 'ftp');
-    
+
   };
-  
+
   subtest 'ftp direct proxy' => sub {
-  
+
     $ENV{ftp_proxy} = 1;
-  
+
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('ftp://mytest.test/');
-    
+
     is([$plugin->pick], ['Fetch::LWP','Decode::DirListing','Decode::HTML']);
     is($plugin->scheme, 'ftp');
-    
+
   };
-  
+
   subtest 'local file URI' => sub {
-  
+
     $ENV{ftp_proxy} = 1;
-  
+
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('file:///foo/bar/baz');
-    
+
     is([$plugin->pick], ['Fetch::Local']);
     is($plugin->scheme, 'file');
-    
+
   };
-  
+
   subtest 'local file' => sub {
-  
+
     $ENV{ftp_proxy} = 1;
-  
+
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('/foo/bar/baz');
-    
+
     is([$plugin->pick], ['Fetch::Local']);
     is($plugin->scheme, 'file');
-    
+
   };
-  
+
   subtest 'bootstrap ssl' => sub {
-  
+
     skip_all 'subtest requires Devel::Hide' unless eval { require Devel::Hide };
 
     subtest 'without Net::SSLeay' => sub {
-  
+
       local @INC = @INC;
       note scalar capture_merged { Devel::Hide->import(qw( Net::SSLeay )) };
 
@@ -84,7 +84,7 @@ subtest 'pick fetch' => sub {
         url           => 'https://mytest.test/',
         bootstrap_ssl => 1,
       );
-  
+
       is(
         [$plugin->pick],
         array {
@@ -94,17 +94,17 @@ subtest 'pick fetch' => sub {
         },
       );
     };
-    
+
     subtest 'with Net::SSLeay' => sub {
 
-      local %INC = %INC;    
+      local %INC = %INC;
       $INC{'Net/SSLeay.pm'} = __FILE__;
 
       my $plugin = Alien::Build::Plugin::Download::Negotiate->new(
         url           => 'https://mytest.test/',
         bootstrap_ssl => 1,
       );
-  
+
       is(
         [$plugin->pick],
         array {
@@ -113,18 +113,18 @@ subtest 'pick fetch' => sub {
           end;
         },
       );
-    
+
     };
 
   };
 
   subtest 'bootstrap ssl http' => sub {
-  
+
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new(
       url           => 'http://mytest.test/',
       bootstrap_ssl => 1,
     );
-  
+
     is(
       [$plugin->pick],
       array {
@@ -149,22 +149,22 @@ subtest 'get the version' => sub {
       filter => qr/\.tar\.gz$/,
     );
   };
-  
+
   note capture_merged {
     $build->download;
     ();
   };
-  
+
   is($build->runtime_prop->{version}, '1.00');
-  
+
   my $filename = $build->install_prop->{download};
-  
+
   ok(-f $filename, "tarball downloaded");
   note "filename = $filename";
-  
+
   my $orig = path('corpus/dist/foo-1.00.tar.gz');
   my $new  = path($filename);
-  
+
   is($new->slurp, $orig->slurp, 'content of file is the same');
 
 };

--- a/t/alien_build_plugin_extract_archivetar.t
+++ b/t/alien_build_plugin_extract_archivetar.t
@@ -10,25 +10,25 @@ use Test2::Mock;
 subtest 'available' => sub {
 
   subtest 'zip' => sub {
-  
+
     # should always be false...
     is(Alien::Build::Plugin::Extract::ArchiveTar->available('zip'), F());
-  
+
   };
 
   subtest 'tar' => sub {
-  
+
     # should always be true...
     is(Alien::Build::Plugin::Extract::ArchiveTar->available('tar'), T());
-  
+
   };
-  
+
   subtest 'tar.gz' => sub {
-  
+
     my $has_it;
 
     skip_all 'test requires Archive::Tar with has_zlib_support' unless eval { require Archive::Tar; Archive::Tar->can('has_zlib_support') };
-  
+
     my $mock = Test2::Mock->new(
       class => 'Archive::Tar',
       override => [
@@ -38,31 +38,31 @@ subtest 'available' => sub {
         },
       ],
     );
-  
+
     subtest 'has it' => sub {
-    
+
       $has_it = 1;
 
       is(Alien::Build::Plugin::Extract::ArchiveTar->available('tar.gz'), T());
-    
+
     };
-    
+
     subtest 'does not' => sub {
-    
+
       $has_it = 0;
-    
+
       is(Alien::Build::Plugin::Extract::ArchiveTar->available('tar.gz'), F());
 
     };
-  
+
   };
 
   subtest 'tar.bz2' => sub {
-  
+
     my $has_it;
 
     skip_all 'test requires Archive::Tar with has_bzip2_support' unless eval { require Archive::Tar; Archive::Tar->can('has_bzip2_support') };
-  
+
     my $mock = Test2::Mock->new(
       class => 'Archive::Tar',
       override => [
@@ -72,28 +72,28 @@ subtest 'available' => sub {
         },
       ],
     );
-  
+
     todo 'detection in Archive::Tar is sometimes broken' => sub {
-    
+
       subtest 'has it' => sub {
-    
+
         $has_it = 1;
 
         is(Alien::Build::Plugin::Extract::ArchiveTar->available('tar.bz2'), T());
-    
+
       };
-    
+
       subtest 'does not' => sub {
-    
+
         $has_it = 0;
-    
+
         is(Alien::Build::Plugin::Extract::ArchiveTar->available('tar.bz2'), F());
 
       };
     };
-  
+
   };
-  
+
 };
 
 subtest 'archive' => sub {
@@ -108,9 +108,9 @@ subtest 'archive' => sub {
       my $plugin = Alien::Build::Plugin::Extract::ArchiveTar->new;
       $plugin->init($meta);
       eval { $build->load_requires('share') };
-    
+
       skip_all "configuration does not support $ext" if $@;
-    
+
       if($ext eq 'tar.bz2')
       {
         skip_all 'Test requires ZLib support in Archive::Tar'
@@ -121,21 +121,21 @@ subtest 'archive' => sub {
         skip_all 'Test requires Bzip2 support in Archive::Tar'
           unless eval { Archive::Tar->has_bzip2_support };
       }
-    
+
       my $archive = path("corpus/dist/foo-1.00.$ext")->absolute;
-      
+
       my($out, $dir, $error) = capture_merged {
         my $dir = eval { $build->extract("$archive") };
         ($dir, $@);
       };
-      
+
       my($bad1, $bad2);
-      
+
       $bad1 = !!$error;
       is $error, '';
 
       note $out if $out ne '';
-      
+
       if(defined $dir)
       {
         $dir = path($dir);
@@ -149,7 +149,7 @@ subtest 'archive' => sub {
           ok -f $file, "$name exists";
         }
       }
-      
+
       if($bad1 || $bad2)
       {
         diag "failed with extension $ext";
@@ -162,7 +162,7 @@ subtest 'archive' => sub {
       }
     }
   }
-  
+
 };
 
 subtest 'archive with pax_global_header' => sub {
@@ -171,7 +171,7 @@ subtest 'archive with pax_global_header' => sub {
     unless eval { require Archive::Tar };
 
   my $build = alienfile_ok q{
-  
+
     use alienfile;
     use Path::Tiny qw( path );
     probe sub { 'share' };
@@ -182,9 +182,9 @@ subtest 'archive with pax_global_header' => sub {
       };
       plugin 'Extract::ArchiveTar';
     };
-  
+
   };
-  
+
   my $dir = alien_extract_ok;
 
   if(defined $dir)
@@ -192,7 +192,7 @@ subtest 'archive with pax_global_header' => sub {
     my $file = path($dir)->child('foo.txt');
     my $content = eval { $file->slurp };
     is($content, "xx\n", "file content matches");
-    
+
     unless(-f $file)
     {
       diag "listing:";
@@ -201,7 +201,7 @@ subtest 'archive with pax_global_header' => sub {
         diag $child;
       }
     }
-    
+
   }
 
 };

--- a/t/alien_build_plugin_extract_archivezip.t
+++ b/t/alien_build_plugin_extract_archivezip.t
@@ -12,11 +12,11 @@ subtest 'available' => sub {
     F(),
     'tar is always false',
   );
-  
+
   subtest 'with Archive::Zip' => sub {
-  
+
     local $INC{'Archive/Zip.pm'} = __FILE__;
-    
+
     is(
       Alien::Build::Plugin::Extract::ArchiveZip->available('zip'),
       T(),
@@ -27,12 +27,12 @@ subtest 'available' => sub {
   subtest 'with Archive::Zip' => sub {
 
     skip_all 'subtest requires Devel::Hide' unless eval { require Devel::Hide };
-    
+
     note scalar capture_merged { Devel::Hide->import(qw( Archive::Zip )) };
-  
+
     local %INC;
     delete $INC{'Archive/Zip.pm'};
-    
+
     is(
       Alien::Build::Plugin::Extract::ArchiveZip->available('zip'),
       F(),
@@ -47,25 +47,25 @@ subtest 'archive' => sub {
   foreach my $ext (qw( zip ))
   {
     subtest "with extension $ext" => sub {
-    
+
       my $build = alienfile '';
       my $meta = $build->meta;
 
       my $plugin = Alien::Build::Plugin::Extract::ArchiveZip->new;
       $plugin->init($meta);
       eval { $build->load_requires('share') };
-    
+
       skip_all "configuration does not support $ext" if $@;
-    
+
       my $archive = path("corpus/dist/foo-1.00.$ext")->absolute;
-      
+
       my($out, $dir, $error) = capture_merged {
         (eval { $build->extract("$archive") }, $@);
       };
 
       note $out if $out ne '';
       note $error if $error;
-      
+
       $dir = path($dir);
 
       ok( defined $dir && -d $dir, "directory created"   );
@@ -78,7 +78,7 @@ subtest 'archive' => sub {
       }
     }
   }
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_extract_commandline.t
+++ b/t/alien_build_plugin_extract_commandline.t
@@ -9,10 +9,10 @@ subtest 'archive' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   my $plugin = Alien::Build::Plugin::Extract::CommandLine->new;
   $plugin->init($meta);
-  
+
   subtest 'command probe' => sub {
 
     foreach my $cmd (qw( gzip bzip2 xz tar unzip ))
@@ -25,22 +25,22 @@ subtest 'archive' => sub {
 
     ok 1;
   };
-  
+
   foreach my $ext (qw( tar tar.Z tar.bz2 tar.gz tar.xz zip ))
   {
     subtest "with extension $ext" => sub {
-    
+
       skip_all "system does not support $ext" unless $plugin->handles($ext);
-    
+
       my $archive = do {
         my $original = path("corpus/dist/foo-1.00.$ext");
         my $new = path(tempdir( CLEANUP => 1))->child("foo-1.00.$ext");
         $original->copy($new);
         $new->stringify;
       };
-      
+
       note "archive = $archive";
-      
+
       my($out, $dir, $error) = capture_merged {
         my $dir = eval { $build->extract($archive) };
         ($dir, $@);
@@ -48,7 +48,7 @@ subtest 'archive' => sub {
 
       note $out if $out ne '';
       note $error if $error;
-      
+
       $dir = path($dir);
 
       ok( defined $dir && -d $dir, "directory created"   );
@@ -61,7 +61,7 @@ subtest 'archive' => sub {
       }
     }
   }
-  
+
 };
 
 subtest 'archive with pax_global_header' => sub {
@@ -69,7 +69,7 @@ subtest 'archive with pax_global_header' => sub {
   skip_all "system does not support tar" unless Alien::Build::Plugin::Extract::CommandLine->new->handles('tar');
 
   my $build = alienfile_ok q{
-  
+
     use alienfile;
     use Path::Tiny qw( path );
     probe sub { 'share' };
@@ -80,9 +80,9 @@ subtest 'archive with pax_global_header' => sub {
       };
       plugin 'Extract::CommandLine';
     };
-  
+
   };
-  
+
   my $dir = alien_extract_ok;
 
   if(defined $dir)
@@ -90,7 +90,7 @@ subtest 'archive with pax_global_header' => sub {
     my $file = path($dir)->child('foo.txt');
     my $content = eval { $file->slurp };
     is($content, "xx\n", "file content matches");
-    
+
     unless(-f $file)
     {
       diag "listing:";
@@ -99,7 +99,7 @@ subtest 'archive with pax_global_header' => sub {
         diag $child;
       }
     }
-    
+
   }
 
 };

--- a/t/alien_build_plugin_extract_directory.t
+++ b/t/alien_build_plugin_extract_directory.t
@@ -36,12 +36,12 @@ subtest 'basic' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   my $plugin = Alien::Build::Plugin::Extract::Directory->new;
   $plugin->init($meta);
-  
+
   $build->install_prop->{download} = path('corpus/dist/foo-1.00')->absolute->stringify;
-  
+
   my($out, $dir) = capture_merged { $build->extract };
 
   $dir = path($dir);
@@ -54,7 +54,7 @@ subtest 'basic' => sub {
     my $file = $dir->child($name);
     ok -f $file, "$name exists";
   }
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_extract_negotiate.t
+++ b/t/alien_build_plugin_extract_negotiate.t
@@ -8,27 +8,27 @@ use Path::Tiny qw( path );
 subtest basic => sub {
 
   my $build = alienfile q{
-  
+
     use alienfile;
-    
+
     probe sub { 'share' };
-    
+
     share {
-    
+
       plugin 'Download' => 'corpus/dist/foo-1.00.tar';
       plugin 'Extract';
-    
+
     };
-    
+
   };
-  
+
   note scalar capture_merged {
     $build->load_requires($build->install_type);
     $build->download;
   };
-  
+
   my $dir = $build->extract;
-  
+
   ok(-d $dir, "extracted to directory");
   note "dir = $dir";
 
@@ -36,9 +36,9 @@ subtest basic => sub {
   {
     my $old  = path('corpus/dist/foo-1.00')->child($filename);
     my $new  = path($dir)->child($filename);
-    
+
     ok(-f $new, "created file $filename");
-    
+
     is($new->slurp, $old->slurp, 'content matches');
   }
 
@@ -54,7 +54,7 @@ subtest 'picks' => sub {
   }
 
   subtest 'tar' => sub {
-  
+
     subtest 'plain' => sub {
       # always
       is(
@@ -62,9 +62,9 @@ subtest 'picks' => sub {
         'Extract::ArchiveTar',
       );
     };
-    
+
     my %available;
-    
+
     my $mock = Test2::Mock->new(
       class => 'Alien::Build::Plugin::Extract::ArchiveTar',
       override => [
@@ -75,9 +75,9 @@ subtest 'picks' => sub {
         },
       ]
     );
-    
+
     subtest 'tar.gz' => sub {
-    
+
       %available = ( 'tar.gz' => 1 );
 
       is(
@@ -96,12 +96,12 @@ subtest 'picks' => sub {
 
     };
   };
-  
+
   subtest 'zip' => sub {
-  
+
     my $have_archive_zip = 0;
     my $have_info_zip    = 0;
-    
+
     my $mock1 = Test2::Mock->new(
       class => 'Alien::Build::Plugin::Extract::ArchiveZip',
       override => [
@@ -111,7 +111,7 @@ subtest 'picks' => sub {
         },
       ],
     );
-    
+
 
     my $mock2 = Test2::Mock->new(
       class => 'Alien::Build::Plugin::Extract::CommandLine',
@@ -122,56 +122,56 @@ subtest 'picks' => sub {
         },
       ],
     );
-    
+
     subtest 'nada' => sub {
-    
+
       is(
         Alien::Build::Plugin::Extract::Negotiate->pick('zip'),
         'Extract::ArchiveZip',
       );
-    
+
     };
 
     subtest 'just Archive::Zip' => sub {
-    
+
       $have_archive_zip = 1;
       $have_info_zip    = 0;
-    
+
       is(
         Alien::Build::Plugin::Extract::Negotiate->pick('zip'),
         'Extract::ArchiveZip',
       );
-    
+
     };
 
     subtest 'just info zip' => sub {
-    
+
       $have_archive_zip = 0;
       $have_info_zip    = 1;
-    
+
       is(
         Alien::Build::Plugin::Extract::Negotiate->pick('zip'),
         'Extract::CommandLine',
       );
-    
+
     };
 
     subtest 'both' => sub {
-    
+
       $have_archive_zip = 1;
       $have_info_zip    = 1;
-    
+
       # Not 100% sure this is the best choice now that I think of it.
       is(
         Alien::Build::Plugin::Extract::Negotiate->pick('zip'),
         'Extract::ArchiveZip',
       );
-    
+
     };
-    
-  
+
+
   };
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_fetch_curlcommand.t
+++ b/t/alien_build_plugin_fetch_curlcommand.t
@@ -12,18 +12,18 @@ $Alien::Build::Plugin::Fetch::CurlCommand::VERSION = '1.19';
 subtest 'fetch from http' => sub {
 
   my $config = test_config 'httpd';
-  
+
   skip_all 'Test requires httpd config' unless $config;
-  
+
   my $base = $config->{url};
 
   my $build = alienfile_ok qq{
     use alienfile;
-    
+
     meta->prop->{start_url} = '$base/html_test.html';
-    
+
     probe sub { 'share' };
-    
+
     share {
       plugin 'Fetch::CurlCommand';
     };
@@ -32,9 +32,9 @@ subtest 'fetch from http' => sub {
   alien_install_type_is 'share';
 
   subtest 'directory listing' => sub {
-  
+
     my $list = capture_note { $build->fetch };
-    
+
     is(
       $list,
       hash {
@@ -47,11 +47,11 @@ subtest 'fetch from http' => sub {
     );
 
   };
-  
+
   subtest 'file' => sub {
-  
+
     my $file = capture_note { $build->fetch("$base/foo-1.01.tar") };
-    
+
     is(
       $file,
       hash {
@@ -62,57 +62,57 @@ subtest 'fetch from http' => sub {
       },
       'file meta',
     );
-    
+
     is(
       scalar path($file->{path})->slurp,
       "content:foo-1.01\n",
       'file content',
     );
-  
+
   };
-  
+
   subtest '404' => sub {
-  
+
     my($file, $error) = capture_note {
       my $file = eval {
         $build->fetch("$base/bogus.html");
       };
       ($file, $@);
     };
-    
+
     isnt $error, '', 'throws error';
     note "error is: $error";
-  
+
   };
-  
+
 };
 
 #subtest 'fetch from ftp' => sub {
 #
 #  my $config = test_config 'ftpd';
-#  
+#
 #  skip_all 'Test requires ftp config' unless $config;
-#  
+#
 #  my $base = $config->{url};
 #
 #  my $build = alienfile_ok qq{
 #    use alienfile;
-#    
+#
 #    meta->prop->{start_url} = '$base/html_test.html';
-#    
+#
 #    probe sub { 'share' };
-#    
+#
 #    share {
 #      plugin 'Fetch::CurlCommand';
 #    };
 #  };
 #
 #  alien_install_type_is 'share';
-#  
+#
 #  subtest 'get directory listing with trailing slash' => sub {
 #
 #    my $list = capture_note { $build->fetch("$base/") };
-#    
+#
 #    is(
 #      $list,
 #      hash {
@@ -131,25 +131,25 @@ subtest 'fetch from http' => sub {
 #      },
 #      'list',
 #    );
-#  
+#
 #  };
-#  
+#
 #  subtest 'get non-existant directory listing with trailing slash' => sub {
-#  
+#
 #    my $error = capture_note {
 #      eval {
 #        $build->fetch("$base/bogus/")
 #      };
 #      $@;
 #    };
-#    
+#
 #    isnt $error, '', 'throws error';
 #    note "error = $error";
-#  
+#
 #  };
-#  
+#
 #  subtest 'get file' => sub {
-#  
+#
 #    my $file = capture_note { $build->fetch("$base/foo-1.01.tar") };
 #
 #    is(
@@ -162,7 +162,7 @@ subtest 'fetch from http' => sub {
 #      },
 #      'file meta',
 #    );
-#  
+#
 #    is(
 #      scalar path($file->{path})->slurp,
 #      "content:foo-1.01\n",
@@ -170,25 +170,25 @@ subtest 'fetch from http' => sub {
 #    );
 #
 #  };
-#  
+#
 #  subtest 'get missing file' => sub {
-#  
+#
 #    my($error) = capture_note {
 #      eval {
 #        $build->fetch("$base/bogus.txt");
 #      };
 #      $@;
 #    };
-#    
+#
 #    isnt $error, '', 'throws error';
 #    note "error is : $error";
-#  
+#
 #  };
 #
 #  subtest 'get directory listing sans trailing slash' => sub {
 #
 #    my $list = capture_note { $build->fetch("$base") };
-#    
+#
 #    is(
 #      $list,
 #      hash {
@@ -207,7 +207,7 @@ subtest 'fetch from http' => sub {
 #      },
 #      'list',
 #    );
-#  
+#
 #  };
 #
 #};

--- a/t/alien_build_plugin_fetch_httptiny.t
+++ b/t/alien_build_plugin_fetch_httptiny.t
@@ -13,9 +13,9 @@ subtest 'updates requires' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
-  
+
   is( $build->requires('share')->{'HTTP::Tiny'}, '0.044' );
   is( $build->requires('share')->{'URI'},         0 );
 
@@ -26,41 +26,41 @@ subtest 'updates requires' => sub {
 subtest 'use start_url' => sub {
 
   subtest 'sets start_url' => sub {
-  
+
     my $build = alienfile_ok q{
-  
+
       use alienfile;
-    
+
       plugin 'Fetch::HTTPTiny' => 'http://foo.bar.baz';
-  
+
     };
-  
+
     is $build->meta_prop->{start_url}, 'http://foo.bar.baz';
-    
+
   };
-  
+
   subtest 'uses start_url' => sub {
-  
+
     my $mock = Test2::Mock->new(class => 'Alien::Build::Plugin::Fetch::HTTPTiny');
     my $plugin;
-    
+
     $mock->after(init => sub {
       my($self, $meta) = @_;
       $plugin = $self;
     });
-  
+
     my $build = alienfile_ok q{
-    
+
       use alienfile;
-      
+
       meta->prop->{start_url} = 'http://baz.bar.foo';
-      
+
       plugin 'Fetch::HTTPTiny';
-    
+
     };
-    
+
     is $plugin->url, 'http://baz.bar.foo';
-  
+
   };
 
 };
@@ -80,7 +80,7 @@ subtest 'fetch' => sub {
   $plugin->init($meta);
   eval { $build->load_requires('share') };
   skip_all 'test requires HTTP::Tiny' if $@;
-  
+
   subtest 'listing' => sub {
     my $res = $build->fetch;
     is(
@@ -92,13 +92,13 @@ subtest 'fetch' => sub {
       },
     );
   };
-  
+
   subtest 'file' => sub {
     my $furl = URI->new_abs("foo-1.00.tar.gz", $url);
     note "url = $furl";
 
     my $expected_content = path('corpus/dist/foo-1.00.tar.gz')->slurp_raw;
-  
+
     my $res = $build->fetch("$furl");
     is(
       $res,

--- a/t/alien_build_plugin_fetch_local.t
+++ b/t/alien_build_plugin_fetch_local.t
@@ -14,13 +14,13 @@ subtest 'basic' => sub {
       url  => 'foo-1.00.tar',
     );
   };
-  
+
   subtest 'default' => sub {
-  
+
     my $res = $build->fetch;
-    
+
     note _dump $res;
-    
+
     is(
       $res,
       hash {
@@ -32,17 +32,17 @@ subtest 'basic' => sub {
       },
       'response hash'
     );
-    
+
     ok( -f $res->{path}, 'path exists as file' );
-  
+
   };
-  
+
   subtest 'listing' => sub {
 
     my $res = $build->fetch('.');
 
     note _dump $res;
-    
+
     is(
       $res,
       hash {
@@ -60,21 +60,21 @@ subtest 'basic' => sub {
       },
       'response hash',
     );
-    
+
     foreach my $url (map { $_->{url} } @{ $res->{list} })
     {
       ok( -e $url );
     }
-  
+
   };
 
 
   subtest 'file' => sub {
-  
+
     my $res = $build->fetch('foo-1.00.tar.gz');
-    
+
     note _dump $res;
-    
+
     is(
       $res,
       hash {
@@ -86,51 +86,51 @@ subtest 'basic' => sub {
       },
       'response hash'
     );
-    
+
     ok( -f $res->{path}, 'path exists as file' );
-  
+
   };
-  
+
 };
 
 subtest 'use start_url' => sub {
 
   subtest 'sets start_url' => sub {
-  
+
     my $build = alienfile_ok q{
-  
+
       use alienfile;
-    
+
       plugin 'Fetch::Local' => 'http://foo.bar.baz';
-  
+
     };
-  
+
     is $build->meta_prop->{start_url}, 'http://foo.bar.baz';
-    
+
   };
-  
+
   subtest 'uses start_url' => sub {
-  
+
     my $mock = Test2::Mock->new(class => 'Alien::Build::Plugin::Fetch::Local');
     my $plugin;
-    
+
     $mock->after(init => sub {
       my($self, $meta) = @_;
       $plugin = $self;
     });
-  
+
     my $build = alienfile_ok q{
-    
+
       use alienfile;
-      
+
       meta->prop->{start_url} = 'http://baz.bar.foo';
-      
+
       plugin 'Fetch::Local';
-    
+
     };
-    
+
     is $plugin->url, 'http://baz.bar.foo';
-  
+
   };
 
 };
@@ -141,7 +141,7 @@ subtest 'uri' => sub {
     unless eval { require URI::file; 1 };
 
   my $url = URI::file->new(path('corpus/dist')->absolute)->as_string;
-  
+
   my $build = alienfile qq{
     use alienfile;
     plugin 'Fetch::Local' => (
@@ -151,11 +151,11 @@ subtest 'uri' => sub {
 
 
   subtest 'listing' => sub {
-  
+
     my $res = $build->fetch($url);
-    
+
     note _dump $res;
-    
+
     is(
       $res,
       hash {
@@ -173,20 +173,20 @@ subtest 'uri' => sub {
       },
       'response hash',
     );
-    
+
     foreach my $url (map { $_->{url} } @{ $res->{list} })
     {
       ok( -e $url );
     }
-  
+
   };
 
   subtest 'file' => sub {
-  
+
     my $res = $build->fetch("$url/foo-1.00.tar.gz");
-    
+
     note _dump $res;
-    
+
     is(
       $res,
       hash {
@@ -198,9 +198,9 @@ subtest 'uri' => sub {
       },
       'response hash'
     );
-    
+
     ok( -f $res->{path}, 'path exists as file' );
-  
+
   };
 
 };

--- a/t/alien_build_plugin_fetch_localdir.t
+++ b/t/alien_build_plugin_fetch_localdir.t
@@ -6,14 +6,14 @@ use Path::Tiny qw( path );
 
 my $build = alienfile_ok q{
   use alienfile;
-  
+
   probe sub { 'share' };
-  
+
   share {
-  
+
     meta->prop->{start_url} = 'corpus/dist/foo-1.00/';
     plugin 'Fetch::LocalDir';
-  
+
   };
 };
 

--- a/t/alien_build_plugin_fetch_lwp.t
+++ b/t/alien_build_plugin_fetch_lwp.t
@@ -15,9 +15,9 @@ subtest 'updates requires' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
-  
+
   is( $build->requires('share')->{'LWP::UserAgent'}, 0 );
 
   note _dump $meta;
@@ -27,41 +27,41 @@ subtest 'updates requires' => sub {
 subtest 'use start_url' => sub {
 
   subtest 'sets start_url' => sub {
-  
+
     my $build = alienfile_ok q{
-  
+
       use alienfile;
-    
+
       plugin 'Fetch::LWP' => 'http://foo.bar.baz';
-  
+
     };
-  
+
     is $build->meta_prop->{start_url}, 'http://foo.bar.baz';
-    
+
   };
-  
+
   subtest 'uses start_url' => sub {
-  
+
     my $mock = Test2::Mock->new(class => 'Alien::Build::Plugin::Fetch::LWP');
     my $plugin;
-    
+
     $mock->after(init => sub {
       my($self, $meta) = @_;
       $plugin = $self;
     });
-  
+
     my $build = alienfile_ok q{
-    
+
       use alienfile;
-      
+
       meta->prop->{start_url} = 'http://baz.bar.foo';
-      
+
       plugin 'Fetch::LWP';
-    
+
     };
-    
+
     is $plugin->url, 'http://baz.bar.foo';
-  
+
   };
 
 };
@@ -85,11 +85,11 @@ subtest 'fetch' => sub {
 
       my $build = alienfile filename => 'corpus/blank/alienfile';
       my $meta = $build->meta;
-  
+
       $plugin->init($meta);
       eval { $build->load_requires('share') };
       skip_all 'test requires LWP' if $@;
-  
+
       subtest 'listing' => sub {
         my $res = $build->fetch;
         is(
@@ -109,13 +109,13 @@ subtest 'fetch' => sub {
           },
          );
       };
-  
+
       subtest 'file' => sub {
         my $furl = URI->new_abs("foo-1.00.tar.gz", $url);
         note "url = $furl";
-    
+
         my $expected_content = path('corpus/dist/foo-1.00.tar.gz')->slurp_raw;
-    
+
         my $res = $build->fetch("$furl");
         is(
           $res,
@@ -126,7 +126,7 @@ subtest 'fetch' => sub {
           },
         );
       };
-  
+
       subtest 'not found' => sub {
         my $furl = URI->new_abs("bogus.tar.gz", $url);
         note "url = $furl";

--- a/t/alien_build_plugin_fetch_netftp.t
+++ b/t/alien_build_plugin_fetch_netftp.t
@@ -13,9 +13,9 @@ subtest 'updates requires' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
-  
+
   is( $build->requires('share')->{'Net::FTP'}, 0 );
   is( $build->requires('share')->{'URI'}, 0 );
 
@@ -26,41 +26,41 @@ subtest 'updates requires' => sub {
 subtest 'use start_url' => sub {
 
   subtest 'sets start_url' => sub {
-  
+
     my $build = alienfile_ok q{
-  
+
       use alienfile;
-    
+
       plugin 'Fetch::NetFTP' => 'http://foo.bar.baz';
-  
+
     };
-  
+
     is $build->meta_prop->{start_url}, 'http://foo.bar.baz';
-    
+
   };
-  
+
   subtest 'uses start_url' => sub {
-  
+
     my $mock = Test2::Mock->new(class => 'Alien::Build::Plugin::Fetch::NetFTP');
     my $plugin;
-    
+
     $mock->after(init => sub {
       my($self, $meta) = @_;
       $plugin = $self;
     });
-  
+
     my $build = alienfile_ok q{
-    
+
       use alienfile;
-      
+
       meta->prop->{start_url} = 'http://baz.bar.foo';
-      
+
       plugin 'Fetch::NetFTP';
-    
+
     };
-    
+
     is $plugin->url, 'http://baz.bar.foo';
-  
+
   };
 
 };
@@ -68,7 +68,7 @@ subtest 'use start_url' => sub {
 subtest 'fetch' => sub {
 
   my $url = ftp_url;
-  
+
   unless($url)
   {
     my $log = path('t/bin/ftpd.log');
@@ -85,12 +85,12 @@ subtest 'fetch' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
 
   eval { $build->load_requires('share') };
   skip_all 'test requires Net::FTP and URI' if $@;
-  
+
   subtest 'listing' => sub {
     my $res = $build->fetch;
     is(
@@ -108,11 +108,11 @@ subtest 'fetch' => sub {
       }
     );
   };
-  
+
   subtest 'file' => sub {
     my $furl = URI->new_abs("foo-1.00.tar.gz", $url);
     note "url = $furl";
-    
+
     my $res = $build->fetch($furl);
     is(
       $res,
@@ -122,12 +122,12 @@ subtest 'fetch' => sub {
         field path     => match qr/foo-1\.00\.tar\.gz$/;
       },
     );
-    
+
     my $expected = path('corpus/dist/foo-1.00.tar.gz')->slurp_raw;
     my $actual = path($res->{path})->slurp_raw;
     is( $actual, $expected );
   };
-  
+
   subtest 'not found' => sub {
     my $furl = URI->new_abs("bogus.tar.gz", $url);
     note "url = $furl";

--- a/t/alien_build_plugin_fetch_wget.t
+++ b/t/alien_build_plugin_fetch_wget.t
@@ -10,18 +10,18 @@ $Alien::Build::Plugin::Fetch::Wget::VERSION = '1.19';
 subtest 'fetch from http' => sub {
 
   my $config = test_config 'httpd';
-  
+
   skip_all 'Test requires httpd config' unless $config;
-  
+
   my $base = $config->{url};
 
   my $build = alienfile_ok qq{
     use alienfile;
-    
+
     meta->prop->{start_url} = '$base/html_test.html';
-    
+
     probe sub { 'share' };
-    
+
     share {
       plugin 'Fetch::Wget';
     };
@@ -30,9 +30,9 @@ subtest 'fetch from http' => sub {
   alien_install_type_is 'share';
 
   subtest 'html' => sub {
-  
+
     my $list = capture_note { $build->fetch };
-    
+
     is(
       $list,
       hash {
@@ -47,9 +47,9 @@ subtest 'fetch from http' => sub {
   };
 
   subtest 'file' => sub {
-  
+
     my $file = capture_note { $build->fetch("$base/foo-1.01.tar") };
-    
+
     is(
       $file,
       hash {
@@ -60,29 +60,29 @@ subtest 'fetch from http' => sub {
       },
       'file meta',
     );
-    
+
     is(
       scalar path($file->{path})->slurp,
       "content:foo-1.01\n",
       'file content',
     );
-  
+
   };
-  
+
   subtest '404' => sub {
-  
+
     my($file, $error) = capture_note {
       my $file = eval {
         $build->fetch("$base/bogus.html");
       };
       ($file, $@);
     };
-    
+
     isnt $error, '', 'throws error';
     note "error is: $error";
-  
+
   };
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_gather_isolatedynamic.t
+++ b/t/alien_build_plugin_gather_isolatedynamic.t
@@ -7,15 +7,15 @@ subtest 'basic' => sub {
 
   my $check = sub {
     my($build) = @_;
-  
+
     note scalar capture_merged {
       $build->probe;
       $build->download;
       $build->build;
     };
-  
+
    my $stage = $build->install_prop->{stage};
- 
+
     ok(-f "$stage/lib/$_", "correct: lib/$_") for qw( libfoo.a );
     ok(-f "$stage/bin/$_", "correct: bin/$_") for qw( foo foo.exe );
 
@@ -39,23 +39,23 @@ subtest 'basic' => sub {
         extract  sub { path($_)->touch for qw( file1 file2 ) };
 
         build sub {
-      
+
           my($build) = @_;
           print "in build\n";
-          
+
           my $dir = path($build->install_prop->{stage});
           $dir->child('lib')->mkpath;
           $dir->child('lib', $_)->touch for qw( libfoo.a libfoo.dylib libfoo.bundle libfoo.la foo.dll.a );
           $dir->child('bin')->mkpath;
           $dir->child('bin', $_)->touch for qw( foo foo.exe foo.dll );
-      
+
         };
 
         plugin 'Gather::IsolateDynamic';
       };
 
     };
-    
+
     $check->($build);
 
   };
@@ -77,7 +77,7 @@ subtest 'basic' => sub {
         extract  sub { path($_)->touch for qw( file1 file2 ) };
 
         build sub {
-      
+
           my($build) = @_;
           print "in build\n";
           my $dir = path(_destdir_prefix($ENV{DESTDIR}, $build->install_prop->{prefix}));
@@ -85,16 +85,16 @@ subtest 'basic' => sub {
           $dir->child('lib', $_)->touch for qw( libfoo.a libfoo.dylib libfoo.bundle libfoo.la foo.dll.a );
           $dir->child('bin')->mkpath;
           $dir->child('bin', $_)->touch for qw( foo foo.exe foo.dll );
-      
+
         };
-      
+
         plugin 'Gather::IsolateDynamic';
       };
     };
-  
+
     $check->($build);
   };
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_pkgconfig_commandline.t
+++ b/t/alien_build_plugin_pkgconfig_commandline.t
@@ -55,7 +55,7 @@ subtest 'available' => sub {
       },
     ],
   );
-  
+
   subtest 'no command line' => sub {
 
     %which = ();
@@ -64,13 +64,13 @@ subtest 'available' => sub {
       Alien::Build::Plugin::PkgConfig::CommandLine->available,
       F(),
     );
-  
+
   };
 
   subtest 'pkg-config' => sub {
-  
+
     %which = ( 'pkg-config' => '/usr/bin/pkg-config' );
-  
+
     is(
       Alien::Build::Plugin::PkgConfig::CommandLine->available,
       T(),
@@ -79,9 +79,9 @@ subtest 'available' => sub {
   };
 
   subtest 'pkgconf' => sub {
-  
+
     %which = ( 'pkgconf' => '/usr/bin/pkgconf' );
-  
+
     is(
       Alien::Build::Plugin::PkgConfig::CommandLine->available,
       T(),
@@ -90,15 +90,15 @@ subtest 'available' => sub {
   };
 
   subtest 'PKG_CONFIG' => sub {
-  
+
     local $ENV{PKG_CONFIG} = 'foo-pkg-config';
     %which = ( 'foo-pkg-config' => '/usr/bin/foo-pkg-config' );
-    
+
     is(
       Alien::Build::Plugin::PkgConfig::CommandLine->available,
       T(),
-    );    
-  
+    );
+
   };
 
 };
@@ -109,9 +109,9 @@ subtest 'system not available' => sub {
 
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'share' );
-  
+
 };
 
 subtest 'system available, wrong version' => sub {
@@ -120,10 +120,10 @@ subtest 'system available, wrong version' => sub {
     pkg_name => 'foo',
     minimum_version => '1.2.4',
   );
-  
+
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'share' );
 
 };
@@ -134,16 +134,16 @@ subtest 'system available, okay' => sub {
     pkg_name => 'foo',
     minimum_version => '1.2.3',
   );
-  
+
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'system' );
-  
+
   return unless $type eq 'system';
-  
+
   note capture_merged { $build->build; () };
-  
+
   if($^O eq 'MSWin32')
   {
     if($build->runtime_prop->{cflags} =~ m/-I(.*)\/include\/foo/
@@ -155,7 +155,7 @@ subtest 'system available, okay' => sub {
       note "-f $prefix/lib/pkgconfig/foo.pc";
     }
   }
-  
+
   is(
     $build->runtime_prop,
     hash {
@@ -167,7 +167,7 @@ subtest 'system available, okay' => sub {
       etc;
     },
   );
-  
+
   # not supported by pkg-config.
   # may be supported by recent pkgconfig
   # so we do not test it.
@@ -183,20 +183,20 @@ subtest 'system available, okay' => sub {
 subtest 'system multiple' => sub {
 
   subtest 'all found in system' => sub {
-  
+
     my $build = alienfile_ok q{
-  
+
       use alienfile;
       plugin 'PkgConfig::CommandLine' => (
         pkg_name => [ 'xor', 'xor-chillout' ],
       );
-  
+
     };
 
-    alien_install_type_is 'system';  
-    
+    alien_install_type_is 'system';
+
     my $alien = alien_build_ok;
-    
+
     use Alien::Build::Util qw( _dump );
     note _dump($alien->runtime_prop);
 
@@ -229,7 +229,7 @@ subtest 'system multiple' => sub {
         etc;
       },
     );
-    
+
   };
 
 };
@@ -241,11 +241,11 @@ subtest 'system rewrite' => sub {
     use Path::Tiny qw( path );
 
     meta->prop->{destdir} = 1;
-    
+
     plugin 'PkgConfig::CommandLine' => (
       pkg_name => [ 'foo-foo' ],
     );
-    
+
     share {
       download sub { path('file1')->touch };
       extract sub { path('file1')->touch };
@@ -253,13 +253,13 @@ subtest 'system rewrite' => sub {
         my($build) = @_;
         my $stage = path($ENV{DESTDIR});
         my $prefix = path($build->install_prop->{prefix});
-        
+
         {
           my $tmp = $prefix->stringify;
           $tmp =~ s!^([a-z]):!/$1!i if $^O eq 'MSWin32';
           $stage = $stage->child($tmp);
         }
-        
+
         $stage->child('lib/pkgconfig')->mkpath;
         $stage->child('lib/libfoofoo.a')->spew("lib foo-foo as staged\n");
 
@@ -274,7 +274,7 @@ subtest 'system rewrite' => sub {
             exec_prefix=${prefix}
             libdir=${prefix}/lib
             includedir=${prefix}/include
-            
+
             Name: foo-foo
             Description: A testing pkg-config file
             Version: 1.2.3
@@ -282,14 +282,14 @@ subtest 'system rewrite' => sub {
             Cflags: -I${includedir}
           },
         );
-        
+
       };
     };
-    
+
   };
-  
+
   alien_install_type_is 'share';
-  
+
   my $alien = alien_build_ok;
 
   subtest 'test from stage' => sub {
@@ -300,11 +300,11 @@ subtest 'system rewrite' => sub {
     ok(-d $inc, "inc dir exists" );
     note "inc = $inc";
     is($inc->child('foofoo.h')->slurp, "h foo-foo as staged\n", 'libfoofoo.a');
-    
+
     ok(-d $lib, "lib dir exists" );
     note "lib = $lib";
     is($lib->child('libfoofoo.a')->slurp, "lib foo-foo as staged\n", 'libfoofoo.a');
-  
+
   };
 
   alien_build_clean;
@@ -317,11 +317,11 @@ subtest 'system rewrite' => sub {
     ok(-d $inc, "inc dir exists" );
     note "inc = $inc";
     is($inc->child('foofoo.h')->slurp, "h foo-foo as staged\n", 'libfoofoo.a');
-    
+
     ok(-d $lib, "lib dir exists" );
     note "lib = $lib";
     is($lib->child('libfoofoo.a')->slurp, "lib foo-foo as staged\n", 'libfoofoo.a');
-  
+
   };
 
 };

--- a/t/alien_build_plugin_pkgconfig_libpkgconf.t
+++ b/t/alien_build_plugin_pkgconfig_libpkgconf.t
@@ -30,7 +30,7 @@ subtest 'available' => sub {
     local $PkgConfig::LibPkgConf::VERSION = '0.04';
     is(Alien::Build::Plugin::PkgConfig::LibPkgConf->available, T());
   };
-  
+
   subtest 'too old!' => sub {
     local $PkgConfig::VERSION = '0.03';
     is(Alien::Build::Plugin::PkgConfig::LibPkgConf->available, F());
@@ -51,9 +51,9 @@ subtest 'system not available' => sub {
 
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'share' );
-  
+
 };
 
 subtest 'system available, wrong version' => sub {
@@ -62,10 +62,10 @@ subtest 'system available, wrong version' => sub {
     pkg_name => 'foo',
     minimum_version => '1.2.4',
   );
-  
+
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'share' );
 
 };
@@ -76,16 +76,16 @@ subtest 'system available, okay' => sub {
     pkg_name => 'foo',
     minimum_version => '1.2.3',
   );
-  
+
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'system' );
-  
+
   return unless $type eq 'system';
-  
+
   note capture_merged { $build->build; () };
-  
+
   is(
     $build->runtime_prop,
     hash {
@@ -97,31 +97,31 @@ subtest 'system available, okay' => sub {
       etc;
     },
   );
-  
+
   is(
     $build->runtime_prop->{alt},
     U(),
   );
-  
+
 };
 
 subtest 'system multiple' => sub {
 
   subtest 'all found in system' => sub {
-  
+
     my $build = alienfile_ok q{
-  
+
       use alienfile;
       plugin 'PkgConfig::LibPkgConf' => (
         pkg_name => [ 'xor', 'xor-chillout' ],
       );
-  
+
     };
 
-    alien_install_type_is 'system';  
-    
+    alien_install_type_is 'system';
+
     my $alien = alien_build_ok;
-    
+
     use Alien::Build::Util qw( _dump );
     note _dump($alien->runtime_prop);
 
@@ -154,7 +154,7 @@ subtest 'system multiple' => sub {
         etc;
       },
     );
-    
+
   };
 
 };
@@ -178,7 +178,7 @@ subtest 'prereqs' => sub {
     );
 
   };
-  
+
   subtest 'minimum version requires util module' => sub {
 
     my $build = alienfile_ok q{
@@ -199,7 +199,7 @@ subtest 'prereqs' => sub {
       'prereqs'
     );
   };
-  
+
   subtest 'are not specified when user asks for plugin IN-directly' => sub {
 
     local $ENV{ALIEN_BUILD_PKG_CONFIG} = 'PkgConfig::LibPkgConf';

--- a/t/alien_build_plugin_pkgconfig_makestatic.t
+++ b/t/alien_build_plugin_pkgconfig_makestatic.t
@@ -11,14 +11,14 @@ subtest 'recursive' => sub {
   my $build = alienfile q{
     use alienfile;
     use Path::Tiny qw( path );
-    
+
     plugin 'PkgConfig::MakeStatic';
-    
+
     probe sub { 'share' };
     plugin 'PkgConfig::PP' => 'foo1';
-    
+
     share {
-    
+
       download sub { path('file1')->touch };
       extract sub  { path('file2')->touch };
       build sub {
@@ -43,13 +43,13 @@ subtest 'recursive' => sub {
   };
 
   note capture_merged {
-    $build->download;  
+    $build->download;
     $build->build;
     ();
   };
 
   like $build->runtime_prop->{libs}, qr{-L/foo/bar -lxml2 -lpthread -lz -liconv -lm};
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_pkgconfig_negotiate.t
+++ b/t/alien_build_plugin_pkgconfig_negotiate.t
@@ -8,7 +8,7 @@ use Capture::Tiny qw( capture_merged );
 subtest 'pick' => sub {
 
   my $pick = Alien::Build::Plugin::PkgConfig::Negotiate->pick;
-  
+
   ok $pick, 'has a pick';
   note "pick = $pick";
 
@@ -20,7 +20,7 @@ subtest 'override' => sub {
   {
     local $ENV{ALIEN_BUILD_PKG_CONFIG} = "PkgConfig::$name";
     subtest $ENV{ALIEN_BUILD_PKG_CONFIG} => sub {
-    
+
       foreach my $minimum_version (undef, '1.2.3')
       {
         subtest "minimum_version = @{[ $minimum_version || 'undef' ]}" => sub {
@@ -29,22 +29,22 @@ subtest 'override' => sub {
             pkg_name        => 'libfoo',
             (defined $minimum_version ? (minimum_version => $minimum_version ) : ()),
           );
-          
+
           my $build = alienfile_ok q{ use alienfile };
-          
+
           my $subplugin;
           my %subplugin;
-          
+
           my $mock = Test2::Mock->new(
             class => 'Alien::Build::Meta',
           );
-          
+
           $mock->before(apply_plugin => sub {
             (undef, $subplugin, %subplugin) = @_;
           });
-          
+
           note scalar capture_merged { $plugin->init($build->meta) };
-          
+
           is(
             [$subplugin, \%subplugin ],
             [
@@ -59,9 +59,9 @@ subtest 'override' => sub {
             'arguments to subplugin are correct',
           );
         }
-          
+
       }
-    
+
     };
   }
 
@@ -84,7 +84,7 @@ subtest 'list of pkg_name' => sub {
     use alienfile;
     plugin 'PkgConfig' => [qw( foo bar baz )];
   };
-  
+
   is(
     \@subplugin,
     [ [ qw( foo bar baz ) ] ],

--- a/t/alien_build_plugin_pkgconfig_negotiate__pick.t
+++ b/t/alien_build_plugin_pkgconfig_negotiate__pick.t
@@ -13,15 +13,15 @@ subtest 'LibPkgConf' => sub {
     subtest 'new enough' => sub {
 
       local $PkgConfig::LibPkgConf::VERSION = '0.99';
-    
+
       is(
         Alien::Build::Plugin::PkgConfig::Negotiate->pick,
         'PkgConfig::LibPkgConf',
       );
     };
-  
+
     subtest 'not new enough' => sub {
-  
+
       local $PkgConfig::LibPkgConf::VERSION = '0.01';
 
       isnt(
@@ -31,21 +31,21 @@ subtest 'LibPkgConf' => sub {
 
     };
   };
-  
+
   subtest 'not installed' => sub {
 
     skip_all 'subtest requires Devel::Hide' unless eval { require Devel::Hide };
     # side-effect of this test, PkgConfig::LibPkgConf
     # cannot be loaded for the rest of this .t file
     note scalar capture_merged { Devel::Hide->import(qw( PkgConfig::LibPkgConf )) };
-  
+
     isnt(
       Alien::Build::Plugin::PkgConfig::Negotiate->pick,
       'PkgConfig::LibPkgConf',
     );
 
   };
-  
+
 };
 
 my $make_pkgconfig_libpkgconf_unavailable = Test2::Mock->new(
@@ -63,7 +63,7 @@ subtest 'CommandLine' => sub {
   my %which;
 
   require File::Which;
-  
+
   my $mock = Test2::Mock->new(
     class => 'File::Which',
     override => [
@@ -88,11 +88,11 @@ subtest 'CommandLine' => sub {
       },
     ],
   );
-  
+
   my $mock2 = Test2::Mock->new(
     class => 'Alien::Build::Plugin::PkgConfig::Negotiate',
   );
-  
+
   if($^O eq 'solaris') {
     $mock2->override(
       _perl_config => sub {
@@ -113,13 +113,13 @@ subtest 'CommandLine' => sub {
       Alien::Build::Plugin::PkgConfig::Negotiate->pick,
       'PkgConfig::PP',
     );
-  
+
   };
 
   subtest 'pkg-config' => sub {
-  
+
     %which = ( 'pkg-config' => '/usr/bin/pkg-config' );
-  
+
     is(
       Alien::Build::Plugin::PkgConfig::Negotiate->pick,
       'PkgConfig::CommandLine',
@@ -128,9 +128,9 @@ subtest 'CommandLine' => sub {
   };
 
   subtest 'pkgconf' => sub {
-  
+
     %which = ( 'pkgconf' => '/usr/bin/pkgconf' );
-  
+
     is(
       Alien::Build::Plugin::PkgConfig::Negotiate->pick,
       'PkgConfig::CommandLine',
@@ -139,26 +139,26 @@ subtest 'CommandLine' => sub {
   };
 
   subtest 'PKG_CONFIG' => sub {
-  
+
     local $ENV{PKG_CONFIG} = 'foo-pkg-config';
     %which = ( 'foo-pkg-config' => '/usr/bin/foo-pkg-config' );
-    
+
     is(
       Alien::Build::Plugin::PkgConfig::Negotiate->pick,
       'PkgConfig::CommandLine',
-    );    
-  
+    );
+
   };
 
   subtest 'PP' => sub {
 
     subtest '64 bit solaris' => sub {
-  
+
       %which = ( 'pkg-config' => '/usr/bin/pkg-config' );
 
       # From the old AB::MB days we prefer PkgConfig.pm
       # for 64 bit solaris over the command line pkg-config
-      
+
       my $mock2 = Test2::Mock->new(
         class => 'Alien::Build::Plugin::PkgConfig::Negotiate',
         override => [
@@ -173,14 +173,14 @@ subtest 'CommandLine' => sub {
           },
         ],
       );
-      
+
       is(
         Alien::Build::Plugin::PkgConfig::Negotiate->pick,
         'PkgConfig::PP',
       );
 
     };
-    
+
     subtest 'PP is fallback' => sub {
 
       %which = ();

--- a/t/alien_build_plugin_pkgconfig_pp.t
+++ b/t/alien_build_plugin_pkgconfig_pp.t
@@ -17,7 +17,7 @@ subtest 'available' => sub {
     local $PkgConfig::VERSION = '0.14026';
     is(Alien::Build::Plugin::PkgConfig::PP->available, T());
   };
-  
+
   subtest 'too old!' => sub {
     local $PkgConfig::VERSION = '0.14025';
     is(Alien::Build::Plugin::PkgConfig::PP->available, F());
@@ -42,9 +42,9 @@ subtest 'system not available' => sub {
 
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'share' );
-  
+
 };
 
 subtest 'system available, wrong version' => sub {
@@ -53,10 +53,10 @@ subtest 'system available, wrong version' => sub {
     pkg_name => 'foo',
     minimum_version => '1.2.4',
   );
-  
+
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'share' );
 
 };
@@ -67,16 +67,16 @@ subtest 'system available, okay' => sub {
     pkg_name => 'foo',
     minimum_version => '1.2.3',
   );
-  
+
   my($out, $type) = capture_merged { $build->probe };
   note $out;
-  
+
   is( $type, 'system' );
-  
+
   return unless $type eq 'system';
-  
+
   note capture_merged { $build->build; () };
-  
+
   is(
     $build->runtime_prop,
     hash {
@@ -87,7 +87,7 @@ subtest 'system available, okay' => sub {
       etc;
     },
   );
-  
+
   note "cflags_static = @{[ $build->runtime_prop->{cflags_static} ]}";
 
   is(
@@ -100,20 +100,20 @@ subtest 'system available, okay' => sub {
 subtest 'system multiple' => sub {
 
   subtest 'all found in system' => sub {
-  
+
     my $build = alienfile_ok q{
-  
+
       use alienfile;
       plugin 'PkgConfig::PP' => (
         pkg_name => [ 'xor', 'xor-chillout' ],
       );
-  
+
     };
 
-    alien_install_type_is 'system';  
-    
+    alien_install_type_is 'system';
+
     my $alien = alien_build_ok;
-    
+
     use Alien::Build::Util qw( _dump );
     note _dump($alien->runtime_prop);
 
@@ -146,7 +146,7 @@ subtest 'system multiple' => sub {
         etc;
       },
     );
-    
+
   };
 
 };
@@ -170,7 +170,7 @@ subtest 'prereqs' => sub {
     );
 
   };
-  
+
   subtest 'are not specified when user asks for plugin IN-directly' => sub {
 
     local $ENV{ALIEN_BUILD_PKG_CONFIG} = 'PkgConfig::PP';

--- a/t/alien_build_plugin_prefer_badversion.t
+++ b/t/alien_build_plugin_prefer_badversion.t
@@ -24,7 +24,7 @@ subtest 'filter is required' => sub {
       plugin 'Prefer::BadVersion';
     }
   };
-  
+
   like $@, qr/The filter property is required for the Prefer::BadVersion plugin/;
 
 };
@@ -39,10 +39,10 @@ subtest 'filters out string version' => sub {
       plugin 'Prefer::BadVersion' => '1.2.5';
     };
   };
-  
+
   my $file = alien_download_ok;
   is(path($file)->slurp, "data:foo-1.2.4.tar.gz");
-  
+
 };
 
 subtest 'filters out list version' => sub {
@@ -55,10 +55,10 @@ subtest 'filters out list version' => sub {
       plugin 'Prefer::BadVersion' => ['1.2.4', '1.2.5'];
     };
   };
-  
+
   my $file = alien_download_ok;
   is(path($file)->slurp, "data:foo-1.2.3.tar.gz");
-  
+
 };
 
 subtest 'filters out code ref' => sub {
@@ -74,10 +74,10 @@ subtest 'filters out code ref' => sub {
       };
     };
   };
-  
+
   my $file = alien_download_ok;
   is(path($file)->slurp, "data:foo-1.2.4.tar.gz");
-  
+
 
 };
 

--- a/t/alien_build_plugin_prefer_sortversions.t
+++ b/t/alien_build_plugin_prefer_sortversions.t
@@ -10,9 +10,9 @@ subtest 'updates requires' => sub {
 
   my $build = alienfile filename => 'corpus/blank/alienfile';
   my $meta = $build->meta;
-  
+
   $plugin->init($meta);
-  
+
   is( $build->requires('share')->{'Sort::Versions'}, 0 );
 
   note _dump $meta;
@@ -29,7 +29,7 @@ subtest 'prefer' => sub {
     eval { $build->load_requires('share') };
     $@ ? () : wantarray ? ($build,$meta) : $build;
   };
-  
+
   my $make_list = sub {
     return {
       type => 'list',
@@ -59,31 +59,31 @@ subtest 'prefer' => sub {
   skip_all 'test requires Sort::Versions' unless $builder->();
 
   subtest 'default settings' => sub {
-  
+
     my $build = $builder->();
-    
+
     my $res = $build->prefer($make_list->(qw(roger-0.0.0.tar.gz abc-2.3.4.tar.gz xyz-1.0.0.tar.gz)));
     note _dump($res);
     is( $res, $make_cmp->(qw( abc-2.3.4.tar.gz xyz-1.0.0.tar.gz roger-0.0.0.tar.gz )) );
-  
+
   };
-  
+
   subtest 'filter' => sub {
-  
+
     my $build = $builder->(filter => qr/abc|xyz/);
     my $res = $build->prefer($make_list->(qw(roger-0.0.0.tar.gz abc-2.3.4.tar.gz xyz-1.0.0.tar.gz)));
     note _dump($res);
     is( $res, $make_cmp->(qw( abc-2.3.4.tar.gz xyz-1.0.0.tar.gz )) );
-  
+
   };
-  
+
   subtest 'version regex' => sub {
-  
+
     my $build = $builder->(qr/^foo-[0-9\.]+-bar-([0-9\.](?:[0-9\.]*[0-9])?)/);
     my $res = $build->prefer($make_list->(qw( foo-10.0-bar-0.1.0.tar.gz foo-5-bar-2.1.0.tar.gz bogus.tar.gz )));
     note _dump($res);
     is( $res, $make_cmp->(qw( foo-5-bar-2.1.0.tar.gz foo-10.0-bar-0.1.0.tar.gz )) );
-    
+
   };
 
 };

--- a/t/alien_build_plugin_probe_cbuilder.t
+++ b/t/alien_build_plugin_probe_cbuilder.t
@@ -12,23 +12,23 @@ subtest 'basic' => sub {
   my $mock = Test2::Mock->new(
     class => 'ExtUtils::CBuilder',
   );
-  
+
   my @args_new;
   my @args_compile;
   my @args_link_executable;
-  
+
   $mock->add('new' => sub {
     shift;
     @args_new = @_;
     bless {}, 'ExtUtils::CBuilder';
   });
-  
+
   $mock->add('compile' => sub {
     shift;
     @args_compile = @_;
     'mytest.o';
   });
-  
+
   $mock->add('link_executable' => sub {
     shift;
     @args_link_executable = @_;
@@ -48,7 +48,7 @@ subtest 'basic' => sub {
     './mytest' => sub { 0 },
     'mytest'   => sub { 0 },
   ;
-  
+
   alien_build_ok;
   alien_install_type_is 'system';
 
@@ -56,7 +56,7 @@ subtest 'basic' => sub {
   is( $build->runtime_prop->{libs}, '-L/usr/local/lib -lfoo ', 'libs' );
 
   is( { @args_new }, { foo1 => 1, bar1 => 2 }, 'options passed to new' );
-  
+
   is(
     { @args_compile },
     hash {
@@ -65,7 +65,7 @@ subtest 'basic' => sub {
       etc;
     },
   );
-  
+
   is(
     { @args_link_executable },
     hash {
@@ -85,19 +85,19 @@ subtest 'program' => sub {
   my $mock = Test2::Mock->new(
     class => 'ExtUtils::CBuilder',
   );
-  
+
   $mock->add('new' => sub {
     bless {}, 'ExtUtils::CBuilder';
   });
-  
+
   my $source;
-  
+
   $mock->add('compile' => sub {
     my(undef, %args) = @_;
     $source = path($args{source})->slurp;
     'mytest.o';
   });
-  
+
   $mock->add('link_executable' => sub {
     'mytest';
   });
@@ -117,7 +117,7 @@ subtest 'program' => sub {
   ;
 
   note capture_merged { $build->probe; () };
-  
+
   is( $build->install_type, 'system', 'is system' );
   is($source, 'int main(int foo1, char *foo2[]) { return 0; }', 'compiled with correct source');
 };
@@ -127,16 +127,16 @@ subtest 'program' => sub {
   my $mock = Test2::Mock->new(
     class => 'ExtUtils::CBuilder',
   );
-  
+
   $mock->add('new' => sub {
     bless {}, 'ExtUtils::CBuilder';
   });
-  
+
   $mock->add('compile' => sub {
     my(undef, %args) = @_;
     'mytest.o';
   });
-  
+
   $mock->add('link_executable' => sub {
     'mytest';
   });
@@ -167,46 +167,46 @@ subtest 'fail' => sub {
   my $mock = Test2::Mock->new(
     class => 'ExtUtils::CBuilder',
   );
-  
+
   $mock->add('new' => sub {
     bless {}, 'ExtUtils::CBuilder';
   });
 
   subtest 'compile' => sub {
-  
+
     $mock->add('compile' => sub {
       my(undef, %args) = @_;
       die "error building mytest.o from mytest.c";
     });
-    
+
     my $build = alienfile_ok q{
-    
+
       use alienfile;
       plugin 'Probe::CBuilder' => (
         cflags => '-DX=1',
         libs   => '-lfoo',
       );
-      
+
       probe sub {
         my($build) = @_;
         # some other plugin tries system
         # but doesn't add a gather step
         'system';
       };
-    
+
     };
-    
+
     alien_install_type_is 'system';
-    
+
     my($out, $err) = capture_merged {
       eval { $build->build };
       $@;
     };
-    
+
     like $err, qr/cbuilder unable to gather;/;
-  
+
   };
-  
+
 };
 
 done_testing;

--- a/t/alien_build_plugin_probe_commandline.t
+++ b/t/alien_build_plugin_probe_commandline.t
@@ -13,17 +13,17 @@ sub cap (&)
   $ret;
 }
 
-sub build 
+sub build
 {
   my $build = alienfile_ok q{ use alienfile };
   my $meta = $build->meta;
-  
+
   if(ref $_[-1] eq 'CODE')
   {
     my $code = pop;
     $code->($build, $meta);
   }
-  
+
   my $plugin = Alien::Build::Plugin::Probe::CommandLine->new(@_);
   $plugin->init($meta);
   ($build, $plugin, $meta);
@@ -34,14 +34,14 @@ subtest 'basic existence' => sub {
   my $guard = system_fake
     'foo' => sub { return 0 },
   ;
-  
+
   subtest 'it is there' => sub {
-  
+
     my($build) = build('foo');
     is cap { $build->probe }, 'system', 'is system';
-  
+
   };
-  
+
   subtest 'it is not there' => sub {
 
     my($build) = build('bar');
@@ -59,13 +59,13 @@ subtest 'args' => sub {
   my $guard = system_fake
     'foo' => sub { $called = 1; @args = @_; return 0 },
   ;
-  
+
   my($build) = build(command => 'foo', args => [1,2,3], match => qr// );
-  
+
   is cap { $build->probe }, 'system', 'is system';
-  
+
   is $called, 1, 'was called';
-  
+
   is \@args, [1,2,3], 'args are passed in';
 
 };
@@ -78,12 +78,12 @@ subtest 'secondary' => sub {
   my $guard = system_fake
     'foo' => sub { $run = 1; return 0 },
   ;
-  
+
   subtest 'libs + command okay' => sub {
-  
+
     $lib = 0;
     $run = 0;
-  
+
     my($build) = build(command => 'foo', secondary => 1, match => qr//, sub {
       my($build, $meta) = @_;
       $meta->register_hook(probe => sub {
@@ -91,18 +91,18 @@ subtest 'secondary' => sub {
         'system';
       });
     });
-    
+
     is(cap { $build->probe }, 'system');
     is $run, 1, 'run';
     is $lib, 1, 'lib';
-  
+
   };
 
   subtest 'libs ok + command bad' => sub {
-  
+
     $lib = 0;
     $run = 0;
-  
+
     my($build) = build(command => 'bar', secondary => 1, match => qr//, sub {
       my($build, $meta) = @_;
       $meta->register_hook(probe => sub {
@@ -110,17 +110,17 @@ subtest 'secondary' => sub {
         'system';
       });
     });
-    
+
     is(cap { $build->probe }, 'share');
     is $lib, 1, 'lib';
-  
+
   };
 
   subtest 'libs bad + command okay' => sub {
-  
+
     $lib = 0;
     $run = 0;
-  
+
     my($build) = build(command => 'foo', secondary => 1, match => qr//, sub {
       my($build, $meta) = @_;
       $meta->register_hook(probe => sub {
@@ -128,18 +128,18 @@ subtest 'secondary' => sub {
         'share';
       });
     });
-    
+
     is(cap { $build->probe }, 'share');
     is $run, 0, 'run';
     is $lib, 1, 'lib';
-  
+
   };
 
   subtest 'libs bad + command bad' => sub {
-  
+
     $lib = 0;
     $run = 0;
-  
+
     my($build) = build(command => 'bar', secondary => 1, match => qr//, sub {
       my($build, $meta) = @_;
       $meta->register_hook(probe => sub {
@@ -147,11 +147,11 @@ subtest 'secondary' => sub {
         'share';
       });
     });
-    
+
     is(cap { $build->probe }, 'share');
     is $run, 0, 'run';
     is $lib, 1, 'lib';
-  
+
   };
 
 };
@@ -161,7 +161,7 @@ subtest 'match + version' => sub {
   my $guard = system_fake
     'foo' => sub { print "Froodle Foomaker version 1.00\n"; return 0 },
   ;
-  
+
   subtest 'match good' => sub {
     my($build) = build(command => 'foo', match => qr/Froodle/);
     is cap { $build->probe }, 'system';
@@ -171,13 +171,13 @@ subtest 'match + version' => sub {
     my($build) = build(command => 'foo', match => qr/Droodle/);
     is cap { $build->probe }, 'share';
   };
-  
+
   subtest 'version found' => sub {
     my($build) = build(command => 'foo', version => qr/version ([0-9\.]+)/);
     is cap { $build->probe }, 'system';
     is $build->runtime_prop->{version}, '1.00';
   };
-  
+
   subtest 'version unfound' => sub {
     my($build) = build(command => 'foo', version => qr/version = ([0-9\.]+)/);
     is cap { $build->probe }, 'system';
@@ -191,7 +191,7 @@ subtest 'match_stderr + version_stderr' => sub {
   my $guard = system_fake
     'foo' => sub { print STDERR "Froodle Foomaker version 1.00\n"; return 0 },
   ;
-  
+
   subtest 'match good' => sub {
     my($build) = build(command => 'foo', match_stderr => qr/Froodle/);
     is cap { $build->probe }, 'system';
@@ -201,13 +201,13 @@ subtest 'match_stderr + version_stderr' => sub {
     my($build) = build(command => 'foo', match_stderr => qr/Droodle/);
     is cap { $build->probe }, 'share';
   };
-  
+
   subtest 'version found' => sub {
     my($build) = build(command => 'foo', version_stderr => qr/version ([0-9\.]+)/);
     is cap { $build->probe }, 'system';
     is $build->runtime_prop->{version}, '1.00';
   };
-  
+
   subtest 'version unfound' => sub {
     my($build) = build(command => 'foo', version_stderr => qr/version = ([0-9\.]+)/);
     is cap { $build->probe }, 'system';

--- a/t/alien_build_rc.t
+++ b/t/alien_build_rc.t
@@ -23,7 +23,7 @@ subtest 'basic' => sub {
   my $build = alienfile_ok q{
     use alienfile;
   };
-  
+
   is $in_foobar, 1;
   is $in_bazfrooble, 1;
 
@@ -45,7 +45,7 @@ subtest 'preload code ref' => sub {
   my $build = alienfile_ok q{
     use alienfile;
   };
-  
+
   isa_ok $meta1, 'Alien::Build::Meta';
   isa_ok $meta2, 'Alien::Build::Meta';
 

--- a/t/alien_build_tempdir.t
+++ b/t/alien_build_tempdir.t
@@ -14,13 +14,13 @@ ok(
 subtest 'cleanup on empty' => sub {
 
   my $tmpdir = Alien::Build::TempDir->new($build, "foo");
-  
+
   ok( -d "$tmpdir", "tempdir = $tmpdir" );
-  
+
   my $str = "$tmpdir";
-  
+
   undef $tmpdir;
-  
+
   ok( ! -d "$str", "directory removed" );
 
 };
@@ -30,15 +30,15 @@ subtest 'do not cleanup non-empty' => sub {
   my $tmpdir = Alien::Build::TempDir->new($build, "bar");
 
   ok( -d "$tmpdir", "tempdir = $tmpdir" );
-  
+
   my $str = "$tmpdir";
-  
+
   path("$str")->child('baz.txt')->touch;
-  
+
   undef $tmpdir;
-  
+
   ok( -d "$str", "directory not removed" );
-  
+
 };
 
 done_testing;

--- a/t/alien_build_util.t
+++ b/t/alien_build_util.t
@@ -10,9 +10,9 @@ use File::Temp qw( tempdir );
 subtest 'dump' => sub {
 
   my $dump = _dump { a => 1, b => 2 }, [ 1..2 ];
-  
+
   isnt $dump, '';
-  
+
   note $dump;
 
 };
@@ -30,20 +30,20 @@ subtest 'mirror' => sub {
   skip_all 'test requires diff' unless which 'diff';
 
   my $tmp1 = Path::Tiny->tempdir("mirror_src_XXXX");
-    
+
   ok -d $tmp1, 'created source directory';
 
   $tmp1->child($_)->mkpath foreach qw( bin etc lib lib/pkgconfig an/empty/one/as/well );
-    
+
   my $bin = $tmp1->child('bin/foomake');
   $bin->spew("#!/bin/sh\necho hi\n");
   eval { chmod 0755, $bin };
-    
+
   $tmp1->child('etc/foorc')->spew("# example\nfoo = 1\n");
   my $lib = $tmp1->child('lib/libfoo.so.1.2.3');
   $lib->spew('XYZ');
   $tmp1->child('lib/pkgconfig/foo.pc')->spew('name=foo');
-    
+
   if($Config{d_symlink})
   {
     foreach my $new (map { $tmp1->child("lib/libfoo$_") } qw( .so.1.2 .so.1 .so ))
@@ -52,36 +52,36 @@ subtest 'mirror' => sub {
       symlink($old, $new->stringify) || die "unable to symlink $new => $old $!";
     }
   }
-    
+
   my $tmp2 = Path::Tiny->tempdir("mirror_dst_XXXX");
 
   _mirror "$tmp1", "$tmp2", { empty_directory => 1 };
-    
+
   my($out, $exit) = capture_merged { system 'diff', '-r', "$tmp1", "$tmp2" };
-  
+
   is $exit, 0, 'diff -r returned true';
-   
+
   $exit ? diag $out : note $out if $out ne '';
-  
+
   if(-x $tmp1->child('bin/foomake'))
   {
     ok(-x $tmp2->child('bin/foomake'), 'dst bin/foomake is executable');
   }
-  
+
   subtest 'filter' => sub {
-  
+
     my $tmp2 = Path::Tiny->tempdir("mirror_dst_XXXX");
 
     note capture_merged {
       _mirror "$tmp1", "$tmp2", { filter => qr/^(bin|etc)\/.*$/, verbose => 1 };
     };
-    
+
     note `ls -lR $tmp2`;
-    
+
     ok( -f $tmp2->child('bin/foomake'), 'bin/foomake' );
     ok( -f $tmp2->child('etc/foorc'), 'bin/foomake' );
     ok( ! -f $tmp2->child('lib/libfoo.so.1.2.3'), 'lib/libfoo.so.1.2.3' );
-  
+
   };
 };
 
@@ -89,7 +89,7 @@ subtest 'destdir_prefix' => sub {
 
   my($destdir) = tempdir( CLEANUP => 1 );
   my($prefix) = tempdir( CLEANUP => 1 );
-  
+
   my $destdir_prefix = path _destdir_prefix($destdir, $prefix);
   note "destdir_prefix = $destdir_prefix";
   eval { $destdir_prefix->mkpath };

--- a/t/alien_build_version_basic.t
+++ b/t/alien_build_version_basic.t
@@ -9,7 +9,7 @@ subtest 'basic' => sub {
     is($version->as_string, '1.2.3');
     is("$version", '1.2.3');
   };
-  
+
   subtest 'version' => sub {
     my $version = version("1.2.3");
     isa_ok $version, 'Alien::Build::Version::Basic';

--- a/t/alienfile.t
+++ b/t/alienfile.t
@@ -29,20 +29,20 @@ subtest 'non struct alienfile' => sub {
   };
   my $error = $@;
   isnt $error, '', 'throws error';
-  note "error = $error"; 
+  note "error = $error";
 
 };
 
 subtest 'warnings alienfile' => sub {
 
-  my $warning = warning { 
+  my $warning = warning {
     alienfile q{
       use alienfile;
       my $foo;
       my $bar = "$foo";
     };
   };
-  
+
   ok $warning;
   note $warning;
 
@@ -51,12 +51,12 @@ subtest 'warnings alienfile' => sub {
 subtest 'plugin' => sub {
 
   subtest 'basic' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       plugin 'RogerRamjet';
     };
-  
+
     is(
       $build->meta->prop,
       hash {
@@ -67,16 +67,16 @@ subtest 'plugin' => sub {
         etc;
       }
     );
-  
+
   };
-  
+
   subtest 'default argument' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       plugin 'RogerRamjet' => 'starscream';
     };
-  
+
     is(
       $build->meta->prop,
       hash {
@@ -87,11 +87,11 @@ subtest 'plugin' => sub {
         etc;
       }
     );
-  
+
   };
-  
+
   subtest 'other arguments' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       plugin 'RogerRamjet' => (
@@ -100,7 +100,7 @@ subtest 'plugin' => sub {
         baz => 'megatron',
       );
     };
-  
+
     is(
       $build->meta->prop,
       hash {
@@ -111,38 +111,38 @@ subtest 'plugin' => sub {
         etc;
       }
     );
-  
+
   };
 
   subtest 'sub package' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       plugin 'NesAdvantage::Controller';
     };
-    
+
     is($build->meta->prop->{nesadvantage}, 'controller');
-  
+
   };
-  
+
   subtest 'negotiate' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       plugin 'NesAdvantage';
     };
-    
+
     is($build->meta->prop->{nesadvantage}, 'negotiate');
-  
+
   };
-  
+
   subtest 'fully qualified class' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       plugin '=Alien::Build::Plugin::RogerRamjet';
     };
-  
+
     is(
       $build->meta->prop,
       hash {
@@ -153,9 +153,9 @@ subtest 'plugin' => sub {
         etc;
       }
     );
-  
+
   };
-  
+
 };
 
 subtest 'probe' => sub {
@@ -170,13 +170,13 @@ subtest 'probe' => sub {
         'share';
       };
     };
-  
+
     is($build->probe, 'share');
     is($build->install_prop->{called_probe}, 1);
   };
-  
+
   subtest 'wrong block' => sub {
-  
+
     eval {
       alienfile q{
         use alienfile;
@@ -185,9 +185,9 @@ subtest 'probe' => sub {
         };
       };
     };
-    
+
     like $@, qr/probe must not be in a system block/;
-  
+
   };
 
 };
@@ -195,7 +195,7 @@ subtest 'probe' => sub {
 subtest 'download' => sub {
 
   subtest 'basic' => sub {
-    
+
     my $build = alienfile q{
       use alienfile;
       use Path::Tiny qw( path );
@@ -204,19 +204,19 @@ subtest 'download' => sub {
         download sub { path('xor-1.00.tar.gz')->touch };
       };
     };
-    
+
     note capture_merged { $build->download; () };
-    
+
     my $download = path($build->install_prop->{download});
-    
+
     is(
       $download->basename,
       'xor-1.00.tar.gz',
     );
   };
-  
+
   subtest 'wrong block' => sub {
-  
+
     eval {
       alienfile q{
         use alienfile;
@@ -225,9 +225,9 @@ subtest 'download' => sub {
         };
       };
     };
-    
+
     like $@, qr/download must be in a share block/;
-  
+
   };
 
 };
@@ -236,7 +236,7 @@ foreach my $hook (qw( fetch decode prefer extract build build_ffi ))
 {
 
   subtest "$hook" => sub {
-  
+
     my(undef, $build) = capture_merged {
       alienfile qq{
         use alienfile;
@@ -245,9 +245,9 @@ foreach my $hook (qw( fetch decode prefer extract build build_ffi ))
         };
       };
     };
-    
+
     ok( $build->meta->has_hook($hook) );
-  
+
   };
 
 }
@@ -255,7 +255,7 @@ foreach my $hook (qw( fetch decode prefer extract build build_ffi ))
 subtest 'gather' => sub {
 
   subtest 'configure' => sub {
-  
+
     eval {
       alienfile q{
         use alienfile;
@@ -264,79 +264,79 @@ subtest 'gather' => sub {
         }
       };
     };
-    
+
     like $@, qr/gather is not allowed in configure block/;
-  
+
   };
-  
+
   subtest 'system + share' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       gather sub {};
     };
-    
+
     is( $build->meta->has_hook('gather_system'), T() );
     is( $build->meta->has_hook('gather_share'),  T() );
-  
+
   };
 
   subtest 'system' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       sys { gather sub {} };
     };
-    
+
     is( $build->meta->has_hook('gather_system'), T() );
     is( $build->meta->has_hook('gather_share'),  F() );
-  
+
   };
 
   subtest 'share' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       share { gather sub {} };
     };
-    
+
     is( $build->meta->has_hook('gather_system'), F() );
     is( $build->meta->has_hook('gather_share'),  T() );
-  
+
   };
 
   subtest 'share + gather_ffi' => sub {
-  
+
     my(undef,$build) = capture_merged {
       alienfile q{
         use alienfile;
         share { gather_ffi sub {} };
       };
     };
-  
+
     is( $build->meta->has_hook('gather_ffi'), T() );
   };
-  
+
 
   subtest 'share + ffi gather' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       share { ffi { gather sub {} } };
     };
-  
+
     is( $build->meta->has_hook('gather_ffi'), T() );
   };
-  
+
   subtest 'nada' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
     };
-    
+
     is( $build->meta->has_hook('gather_system'), F() );
     is( $build->meta->has_hook('gather_share'),  F() );
-  
+
   };
 
 };
@@ -347,7 +347,7 @@ subtest 'prop' => sub {
     use alienfile;
     meta_prop->{foo1} = 'bar1';
   };
-  
+
   is( $build->meta_prop->{foo1}, 'bar1' );
 
 };
@@ -358,7 +358,7 @@ subtest 'patch' => sub {
     use alienfile;
     share { patch sub { } };
   };
-  
+
   is( $build->meta->has_hook('patch'), T() );
 
 };
@@ -371,7 +371,7 @@ subtest 'patch_ffi' => sub {
       share { patch_ffi sub { } };
     };
   };
-  
+
   is( $build->meta->has_hook('patch_ffi'), T() );
 
 };
@@ -382,7 +382,7 @@ subtest 'ffi patch' => sub {
     use alienfile;
     share { ffi { patch sub { } } };
   };
-  
+
   is( $build->meta->has_hook('patch_ffi'), T() );
 
 };
@@ -390,31 +390,31 @@ subtest 'ffi patch' => sub {
 subtest 'arch' => sub {
 
   subtest 'on' => sub {
-  
+
     my $build = alienfile q{
       use alienfile;
       meta_prop->{arch} = 1;
     };
-    
+
     is( $build->meta_prop->{arch}, T());
-  
+
   };
-  
+
   subtest 'off' => sub {
 
     my $build = alienfile q{
       use alienfile;
       meta_prop->{arch} = 0;
     };
-  
+
     is( $build->meta_prop->{arch}, F());
   };
-  
+
   subtest 'default' => sub {
     my $build = alienfile q{
       use alienfile;
     };
-  
+
     is( $build->meta_prop->{arch}, T());
   };
 
@@ -426,9 +426,9 @@ subtest 'meta' => sub {
     use alienfile;
     meta->prop->{foo} = 1;
     probe sub { 'system' };
-  
+
   };
-  
+
   is $build->meta_prop->{foo}, 1;
 
 };
@@ -443,7 +443,7 @@ subtest 'test' => sub {
         test [];
       };
     };
-    
+
     is(
       $build->requires('configure'),
       hash {
@@ -452,29 +452,29 @@ subtest 'test' => sub {
       },
     );
   };
-  
+
   alienfile_ok q{
-  
+
     use alienfile;
-    
+
     sys {
       test [];
     };
-  
+
   };
-  
+
   alienfile_ok q{
-  
+
     use alienfile;
-    
+
     share {
       ffi {
         test [];
       };
     };
-  
+
   };
-  
+
   eval {
     alienfile q{
       use alienfile;
@@ -482,7 +482,7 @@ subtest 'test' => sub {
     };
   };
   like $@, qr/test is not allowed in any block/, 'not allowed in root block';
-  
+
   eval {
     alienfile q{
       use alienfile;
@@ -501,7 +501,7 @@ subtest 'start_url' => sub {
       start_url 'http://bogus.com';
     };
   };
-  
+
   is(
     $build,
     object {

--- a/t/lib/MyTest/FTP.pm
+++ b/t/lib/MyTest/FTP.pm
@@ -43,7 +43,7 @@ sub ftp_url
   my $ftp = Net::FTP->new($url->host, Port =>  $url->port) or do {
     return ftp_error("Connot connect to @{[ $url->host ]}");
   };
-  
+
   eval {
     $ftp->login($url->user, $url->password) or die;
     $ftp->binary;
@@ -53,12 +53,12 @@ sub ftp_url
     -e $path || die;
     $ftp->quit;
   };
-  
+
   return ftp_error($ftp->message) if $@;
 
   $url->path($url->path . '/')
     unless $url->path =~ m!/$!;
-  
+
   return $url;
 }
 

--- a/t/lib/MyTest/FauxFetchCommand.pm
+++ b/t/lib/MyTest/FauxFetchCommand.pm
@@ -16,11 +16,11 @@ sub capture_note (&)
 {
   my($code) = @_;
   my($out, $error, @ret) = Capture::Tiny::capture_merged(sub { my @ret = eval { $code->() }; ($@, @ret) });
-  
+
   my $ctx = context();
   $ctx->note($out) if $out ne '';
   $ctx->release;
-  
+
   die $error if $error;
   wantarray ? @ret : $ret[0];
 }
@@ -33,16 +33,16 @@ my %record = %{ decode_json path("corpus/$test_name/record/old.json")->slurp };
 sub real_cmd
 {
   my(@args) = @_;
-  
+
   my %old = map { $_->basename => 1 } path('.')->children;
-  
+
   my($stdout, $stderr, $exit) = tee {
     CORE::system $command_name, @args;
     $? >> 8;
   };
 
-  my $key = "@args";  
-  
+  my $key = "@args";
+
   for($key, $stdout, $stderr)
   {
     s{http://localhost.*?/corpus}{http://localhost/corpus}g;
@@ -59,31 +59,31 @@ sub real_cmd
       $files{$child->basename} = $child->slurp;
     }
   }
-  
+
   $record{$key} = {
     stdout => $stdout,
     stderr => $stderr,
     exit   => $exit,
     files  => \%files,
   };
-  
+
   $exit;
 }
 
 sub faux_cmd
 {
   my(@args) = @_;
-  
+
   my $key = "@args";
-  
+
   unless($record{$key})
   {
     my $ctx = context();
     $ctx->bail("do not have a record for $command_name $key");
   }
-  
+
   my $run = $record{$key};
-  
+
   print STDOUT $run->{stdout};
   print STDERR $run->{stderr};
 
@@ -99,38 +99,38 @@ sub test_config ($)
 {
   my($name) = @_;
   my $path = path("t/bin/$name.json");
-  
+
   if(-f $path)
   {
     my $config = JSON::PP::decode_json(scalar $path->slurp);
-    
+
     my $guard = system_fake;
-    
+
     $guard->add($command_name        => \&real_cmd);
     $guard->add("/bin/$command_name" => \&real_cmd);
-    
+
     $config->{url} =~ s{dist/?$}{$test_name/dir};
     $config->{guard} = $guard;
 
     my $ctx = context();
     $ctx->note("testing against real $command_name and real $name @{[ $config->{url} ]}");
     $ctx->release;
-    
+
     return $config;
   }
   eles
   {
     my %config;
     my $guard = system_fake;
-    
+
     $guard->add($command_name        => \&faux_cmd);
     $guard->add("/bin/$command_name" => \&faux_cmd);
-    
+
     $config{guard} = $guard;
     $config{url}   = $name eq 'httpd'
       ? "http://localhost/corpus/$test_name/dir"
       : "ftp://localhost/corpus/$test_name/dir";
-    
+
     return \%config;
   }
 }

--- a/t/lib/MyTest/System.pm
+++ b/t/lib/MyTest/System.pm
@@ -35,10 +35,10 @@ my @stack;
 {
   my $old = \&File::Which::which;
   no warnings 'redefine';
-  *File::Which::which = sub 
+  *File::Which::which = sub
   {
     my $system = $stack[-1];
-    
+
     if($system)
     {
       $system->can_run(@_);
@@ -68,14 +68,14 @@ sub add
 sub call
 {
   my($self, $command, @args) = @_;
-  
+
   if(@args == 0)
   {
     if($^O eq 'MSWin32' && $command =~ /^"(.*)"$/)
     { $command = $1 }
     ($command, @args) = shellwords $command;
   }
-  
+
   if($self->{$command})
   {
     my $exit = $self->{$command}->(@args);
@@ -94,7 +94,7 @@ sub can_run
 
   # we only really use can_run to figure out if
   # we CAN run an executable, but make up some
-  # path just for pretends.  
+  # path just for pretends.
   $self->{$command}
   ? "/bin/$command"
   : undef;

--- a/t/test_alien.t
+++ b/t/test_alien.t
@@ -19,7 +19,7 @@ subtest 'alien_ok' => sub {
   local $ENV{PATH} = $ENV{PATH};
 
   subtest 'as class' => sub {
-  
+
     local $ENV{PATH} = $ENV{PATH};
 
     is(
@@ -39,7 +39,7 @@ subtest 'alien_ok' => sub {
   };
 
   subtest 'as object' => sub {
-  
+
     local $ENV{PATH} = $ENV{PATH};
 
     my $alien = Alien::Foo->new;
@@ -103,7 +103,7 @@ subtest 'alien_ok' => sub {
     },
     'alien_ok with undef',
   );
-  
+
 };
 
 subtest 'helper_ok' => sub {
@@ -241,7 +241,7 @@ subtest 'interpolate_template_is' => sub {
 subtest 'ffi_ok' => sub {
 
   skip_all 'Test requires FFI::Platypus'
-    unless eval { require FFI::Platypus; 1 };  
+    unless eval { require FFI::Platypus; 1 };
 
   _reset();
 
@@ -292,7 +292,7 @@ subtest 'ffi_ok' => sub {
           },
         ],
       );
-      
+
       is(
         intercept { ffi_ok { symbols => [qw( foo bar baz )] } },
         array {
@@ -303,7 +303,7 @@ subtest 'ffi_ok' => sub {
         },
         'test passes',
       );
-      
+
       is(
         \@symbols,
         [qw( foo bar baz )],
@@ -336,7 +336,7 @@ subtest 'ffi_ok' => sub {
   };
 
   subtest 'acme' => sub {
-  
+
     skip_all 'Test requires Acme::Alien::DontPanic 0.026'
       unless eval {
          require Acme::Alien::DontPanic;
@@ -443,7 +443,7 @@ EOF
       my($module) = @_;
       is $module->baz(), 42, "call $module->baz()";
     };
-  
+
     $xs =~ s{\bTA_MODULE\b}{Foo::Bar}g;
     xs_ok $xs, 'xs without parameterized name', with_subtest {
       my($module) = @_;
@@ -452,7 +452,7 @@ EOF
     };
 
   };
-  
+
   subtest 'with xs_load' => sub {
 
     _reset();
@@ -528,7 +528,7 @@ EOF
   };
 
   subtest 'acme' => sub {
-  
+
     skip_all 'Test requires Acme::Alien::DontPanic 0.026'
       unless eval {
          require Acme::Alien::DontPanic;
@@ -606,13 +606,13 @@ subtest 'xs_ok without no compiler' => sub {
     },
     'skip works with cb'
   );
-  
+
 };
 
 subtest 'overrides no overrides' => sub {
 
   _reset();
-  
+
   alien_ok synthetic { cflags => '-DD1=22' };
 
   my $xs = <<'EOF';

--- a/t/test_alien_build.t
+++ b/t/test_alien_build.t
@@ -10,7 +10,7 @@ subtest 'alienfile_ok' => sub {
     my $build = alienfile q{
       use alienfile;
     };
-  
+
     isa_ok $build, 'Alien::Build';
 
     ok(-d $build->install_prop->{prefix}, "has prefix dir");
@@ -27,7 +27,7 @@ subtest 'alienfile_ok' => sub {
   subtest 'from file' => sub {
 
     my $build = alienfile filename => 'corpus/basic/alienfile';
-  
+
     isa_ok $build, 'Alien::Build';
 
     ok(-d $build->install_prop->{prefix}, "has prefix dir");
@@ -64,7 +64,7 @@ subtest 'alienfile_ok' => sub {
 
   alienfile_ok q{
     use alienfile;
-  
+
     log('hey there');
   };
 
@@ -73,11 +73,11 @@ subtest 'alienfile_ok' => sub {
 subtest alien_build_ok => sub {
 
   subtest 'no alienfile' => sub {
-  
+
     eval { alienfile q{ die } };
-    
+
     my $ret;
-    
+
     is(
       intercept { $ret = alien_build_ok },
       array {
@@ -92,26 +92,26 @@ subtest alien_build_ok => sub {
         end;
       },
     );
-    
+
     is $ret, U();
-  
+
   };
-  
+
   subtest 'alienfile compiles but does not run' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
-      
+
       probe sub { 'share' };
-      
+
       share {
         download sub { die 'dinosaurs and transformers' };
         build sub {};
       }
     };
-    
+
     my $ret;
-    
+
     is(
       intercept { $ret = alien_build_ok },
       array {
@@ -127,12 +127,12 @@ subtest alien_build_ok => sub {
         end;
       },
     );
-  
+
     is $ret, U();
   };
-  
+
   subtest 'good system' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
       probe sub { 'system' };
@@ -144,18 +144,18 @@ subtest alien_build_ok => sub {
         };
       };
     };
-    
+
     my $alien = alien_build_ok;
-    
+
     isa_ok $alien, 'Alien::Base';
-    
+
     is $alien->cflags,  '-DFOO=1';
     is $alien->libs,    '-lfoo';
-  
+
   };
-  
+
   subtest 'good share' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
       use Path::Tiny qw( path );
@@ -175,16 +175,16 @@ subtest alien_build_ok => sub {
         };
       };
     };
-    
+
     my $alien = alien_build_ok;
-    
+
     isa_ok $alien, 'Alien::Base';
-    
+
     my $prefix = $alien->runtime_prop->{prefix};
-    
+
     is $alien->cflags, "-I$prefix/include -DFOO=1";
     is $alien->libs,   "-L$prefix/lib -lfoo";
-    
+
     ok -f path($prefix)->child('file3');
   };
 
@@ -198,7 +198,7 @@ subtest 'alien_install_type_is' => sub {
   subtest 'no alienfile' => sub {
 
     eval { alienfile q{ die } };
-    
+
     is(
       intercept { $ret = alien_install_type_is 'system' },
       array {
@@ -214,17 +214,17 @@ subtest 'alien_install_type_is' => sub {
       },
       'test for anything',
     );
-  
+
     is $ret, F(), 'return false';
   };
-  
+
   subtest 'is system' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
       probe sub { 'system' };
     };
-    
+
     is(
       intercept { $ret = alien_install_type_is 'system', 'some name' },
       array {
@@ -236,7 +236,7 @@ subtest 'alien_install_type_is' => sub {
       },
       'check for system',
     );
-    
+
     is $ret, T(), 'return true';
 
     is(
@@ -254,18 +254,18 @@ subtest 'alien_install_type_is' => sub {
       },
       'check for share',
     );
-    
+
     is $ret, F(), 'return false';
-  
+
   };
 
   subtest 'is share' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
       probe sub { 'share' };
     };
-    
+
     is(
       intercept { $ret = alien_install_type_is 'share', 'some other name' },
       array {
@@ -277,7 +277,7 @@ subtest 'alien_install_type_is' => sub {
       },
       'check for share',
     );
-    
+
     is $ret, T(), 'return true';
 
     is(
@@ -295,11 +295,11 @@ subtest 'alien_install_type_is' => sub {
       },
       'check for system',
     );
-    
+
     is $ret, F(), 'return false';
-  
+
   };
-  
+
 };
 
 subtest 'alien_download_ok' => sub {
@@ -316,9 +316,9 @@ subtest 'alien_download_ok' => sub {
         };
       };
     };
-    
+
     my $file = alien_download_ok;
-    
+
     is(
       path($file)->slurp,
       "xx\n",
@@ -337,9 +337,9 @@ subtest 'alien_download_ok' => sub {
         };
       };
     };
-    
+
     my $file;
-    
+
     is(
       intercept { $file = alien_download_ok },
       array {
@@ -350,7 +350,7 @@ subtest 'alien_download_ok' => sub {
       },
       'test fails',
     );
-    
+
     is($file, U(), 'return value is undef');
 
   };
@@ -360,7 +360,7 @@ subtest 'alien_download_ok' => sub {
 subtest 'alien_extract_ok' => sub {
 
   subtest 'good extract' => sub {
-  
+
     alienfile_ok q{
       use alienfile;
       use Path::Tiny qw( path );
@@ -374,15 +374,15 @@ subtest 'alien_extract_ok' => sub {
         };
       };
     };
-    
+
     my $dir = alien_extract_ok;
-    
+
     is(-d $dir, T(), "dir is dir" );
     is(-f path("$dir/file2"), T(), "has file2" );
     is(-f path("$dir/file3"), T(), "has file3" );
-  
+
   };
-  
+
   subtest 'bad extract' => sub {
 
     alienfile_ok q{
@@ -399,7 +399,7 @@ subtest 'alien_extract_ok' => sub {
       };
     };
 
-    my $dir;    
+    my $dir;
     is(
       intercept { $dir = alien_extract_ok },
       array {
@@ -410,10 +410,10 @@ subtest 'alien_extract_ok' => sub {
       },
       'test fails',
     );
-    
+
     is( $dir, U(), "dir is undef");
   };
-  
+
 };
 
 subtest 'alien_rc' => sub {
@@ -421,44 +421,44 @@ subtest 'alien_rc' => sub {
   subtest 'create rc' => sub {
 
     alien_rc q{
-  
+
       preload 'Foo::Bar';
-    
+
       package Alien::Build::Plugin::Foo::Bar;
-    
+
       use Alien::Build::Plugin;
-    
+
       sub init
       {
         my($self, $meta) = @_;
         $meta->prop->{x} = 'y';
       }
-  
+
     };
 
     note path($ENV{ALIEN_BUILD_RC})->slurp;
 
     my $build = alienfile_ok q{ use alienfile };
-  
+
     is(
       $build->meta_prop->{x}, 'y',
     );
   };
-  
+
 };
 
 subtest 'test for custom subtest' => sub {
 
   subtest 'basic pass' => sub {
-  
+
     my $ok;
-  
+
     my $events = intercept {
       $ok = alien_subtest 'foo' => sub {
         ok 1;
       };
     };
-    
+
     is(
       $events,
       array {
@@ -473,24 +473,24 @@ subtest 'test for custom subtest' => sub {
         end;
       },
     );
-    
+
     is(
       $ok,
       T(),
     );
-  
+
   };
-  
+
   subtest 'basic fail' => sub {
 
     my $ok;
-  
+
     my $events = intercept {
       $ok = alien_subtest 'foo' => sub {
         ok 0;
       };
     };
-    
+
     is(
       $events,
       array {
@@ -506,7 +506,7 @@ subtest 'test for custom subtest' => sub {
         end;
       },
     );
-    
+
     is(
       $ok,
       F(),
@@ -519,7 +519,7 @@ subtest 'test for custom subtest' => sub {
 subtest 'alien_checkpoint_ok' => sub {
 
   alien_subtest 'without build' => sub {
-  
+
     is(
       intercept { alien_checkpoint_ok },
       array {
@@ -534,13 +534,13 @@ subtest 'alien_checkpoint_ok' => sub {
         end;
       },
     );
-  
+
   };
-  
+
   alien_subtest 'with failure in checkpont' => sub {
-  
+
     alienfile_ok q{ use alienfile };
-    
+
     my $mock = Test2::Mock->new(
       class => 'Alien::Build',
       override => [
@@ -549,7 +549,7 @@ subtest 'alien_checkpoint_ok' => sub {
         },
       ],
     );
-    
+
     is(
       intercept { alien_checkpoint_ok },
       array {
@@ -564,13 +564,13 @@ subtest 'alien_checkpoint_ok' => sub {
         end;
       },
     );
-  
+
   };
-  
+
   alien_subtest 'with goodness and light' => sub {
-  
+
     alienfile_ok q{ use alienfile };
-    
+
     is(
       intercept { alien_checkpoint_ok },
       array {
@@ -581,7 +581,7 @@ subtest 'alien_checkpoint_ok' => sub {
         end;
       },
     );
-  
+
   };
 
 };
@@ -589,7 +589,7 @@ subtest 'alien_checkpoint_ok' => sub {
 subtest 'alien_resume_ok' => sub {
 
   alien_subtest 'with no build' => sub {
-  
+
     is(
       intercept { alien_resume_ok },
       array {
@@ -604,13 +604,13 @@ subtest 'alien_resume_ok' => sub {
         end;
       },
     );
-  
+
   };
-  
+
   subtest 'without checkpoint' => sub {
-  
+
     alienfile_ok q{ use alienfile };
-  
+
     is(
       intercept { alien_resume_ok },
       array {
@@ -625,13 +625,13 @@ subtest 'alien_resume_ok' => sub {
         end;
       },
     );
-  
+
   };
-  
+
   subtest 'die in resume' => sub {
-  
+
     alienfile_ok q{ use alienfile };
-    
+
     my $mock = Test2::Mock->new(
       class => 'Alien::Build',
       override => [
@@ -640,9 +640,9 @@ subtest 'alien_resume_ok' => sub {
         },
       ],
     );
-    
+
     alien_checkpoint_ok;
-    
+
     is(
       intercept { alien_resume_ok },
       array {
@@ -659,14 +659,14 @@ subtest 'alien_resume_ok' => sub {
     );
 
   };
-  
+
   subtest 'goodness and light' => sub {
-  
+
     alienfile_ok q{ use alienfile };
     alien_checkpoint_ok;
-    
+
     my $build;
-    
+
     is(
       intercept { $build = alien_resume_ok },
       array {
@@ -677,9 +677,9 @@ subtest 'alien_resume_ok' => sub {
         end;
       },
     );
-    
+
     isa_ok $build, 'Alien::Build';
-  
+
   };
 
 };

--- a/t/test_alien_run.t
+++ b/t/test_alien_run.t
@@ -10,7 +10,7 @@ BEGIN {
   *File::Which::which = sub {
     $which->(@_);
   };
-  
+
   $system = sub {
     CORE::system(@_);
   };
@@ -39,7 +39,7 @@ subtest 'run with exit 0' => sub {
     print "this is some output";
     print STDERR "this is some error";
   };
-  
+
   is(
     intercept { $run = run_ok [ $^X, $prog ], 'run it!' },
     array {


### PR DESCRIPTION
While preparing #44 I realised that the files I was modifying had some trailing whitespace. Since my editor removes all trailing whitespace automatically when saving, these changes were cluttering the output of `git diff`, so I thought I'd put all the trailing spaces in a separate PR in case you wanted to pull that in as well.

This most decisively cosmetic patch removes the trailing whitespace in all files, except those that are generated during the build process (some of which, according to Dist::Zilla::Plugin::Test::TrailingSpace, apparently have trailing spaces of their own).
