### PR TITLE
Add before and after directives to alienfile

### DIFF
--- a/lib/Alien/Build/Manual/FAQ.pod
+++ b/lib/Alien/Build/Manual/FAQ.pod
@@ -255,6 +255,27 @@ You can also patch using Perl if that is easier:
    build [ ... ];
  };
 
+=head2 The flags that a plugin produces are wrong!
+
+Sometimes, the compiler or linker flags that the PkgConfig plugin comes up with are not quite
+right.  (Frequently this is actually because a package maintainer is providing a broken
+C<.pc> file).  (Other plugins may also have problems).  You could replace the plugin's C<gather> step
+but a better way is to provide a subroutine callback to be called after the gather stage
+is complete.  You can do this with the L<alienfile> C<after> directive:
+
+ use alienfile;
+ 
+ plugin 'PlgConfig' => 'libfoo';
+ 
+ share {
+   ...
+   after 'gather' => sub {
+     my($build) = @_;
+     $build->runtime_prop->{libs}        .= " -lbar";        # libfoo also requires libbar
+     $build->runtime_prop->{libs_static} .= " -lbar -lbaz";  # libfoo also requires libbaz under static linkage
+   };
+ };
+
 =head2 599 Internal Exception errors downloading packages from the internet
 
  Alien::Build::Plugin::Fetch::HTTPTiny> 599 Internal Exception fetching http://dist.libuv.org/dist/v1.15.0

--- a/lib/Alien/Build/Manual/FAQ.pod
+++ b/lib/Alien/Build/Manual/FAQ.pod
@@ -276,6 +276,23 @@ is complete.  You can do this with the L<alienfile> C<after> directive:
    };
  };
 
+Sometimes you only need to do this on certain platforms.  You can adjust the logic based on C<$^O>
+appropriately.
+
+ use alienfile;
+ 
+ plugin 'PlgConfig' => 'libfoo';
+ 
+ share {
+   ...
+   after 'gather' => sub {
+     my($build) = @_;
+     if($^O eq 'MSWin32') {
+       $build->runtime_prop->{libs} .= " -lpsapi";
+     }
+   };
+ };
+
 =head2 599 Internal Exception errors downloading packages from the internet
 
  Alien::Build::Plugin::Fetch::HTTPTiny> 599 Internal Exception fetching http://dist.libuv.org/dist/v1.15.0


### PR DESCRIPTION
The idea has always been for authors of Alien distributions to use the simplified but powerful-enough `alienfile` syntax and for the `$build->meta` interface to be for plugin authors.  It is sometimes necessary for Alien authors to get under the hood with `meta->{after,around,before}_hook` to customize things, so we do provide that as an interface in a pinch, but anytime you need to do that for more than one or two Aliens we should reconsider the `alienfile` interface to make it more powerful.

One thing that you really need to be able to do is have a callback called after the gather stage for alienized packages that have borken `.pc` files (other issues can also make this a helpful technique as well).  This patch provides an interface to the `after_hook` and `before_hook` API to make this easier.  Also included is a FAQ covering this specific challenge.

For now I am proposing not make an interface to `around_hook`.  There are a couple of `alienfiles` that make an `around_hook`, but they are unusual use cases.  If this is required for mainstream type cases we can reconsider.