### PR TITLE
Improve Alien::Build plugin testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ perl:
   - "5.22"
   - "5.24"
   - "5.26"
+  - "5.28"
 
 script:
   - ./maint/travis-run-test

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Added Alien::Build::Plugin::Test::Mock
+  - Added alienfile_skip_if_missing_prereqs function to Test::Alien::Build
   - Remove run-time dependency on Test2::Suite
     Test2::API is still a run-time dependency, but that has
     been in-core since 5.26.

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -841,7 +841,7 @@ sub load_requires
     my $check = sub {
       my $pm = "$mod.pm";
       $pm =~ s{::}{/}g;
-      $pm;
+      require $pm;
     };
     if($eval)
     {

--- a/lib/Alien/Build/MM.pm
+++ b/lib/Alien/Build/MM.pm
@@ -219,7 +219,7 @@ sub mm_args
 
 =head2 mm_postamble
 
- my %args = $abmm->mm_args(%args);
+ my $postamble $abmm->mm_postamble;
 
 Returns the postamble for the C<Makefile> needed for L<Alien::Build>.
 This adds the following C<make> targets which are normally called when

--- a/lib/Alien/Build/Plugin/Test/Mock.pm
+++ b/lib/Alien/Build/Plugin/Test/Mock.pm
@@ -6,6 +6,9 @@ use Alien::Build::Plugin;
 use Carp ();
 use File::chdir;
 
+# ABSTRACT: Mock plugin for testing
+# VERSION
+
 =head1 SYNOPSIS
 
  use alienfile;
@@ -84,6 +87,22 @@ C<foo-1.00.tar.gz>.
 
 has 'download';
 
+=head2 extract
+
+ plugin 'Test::Mock' => (
+   extract => %fs_spec,
+ );
+ 
+ plugin 'Test::Mock' => (
+   extract => 1, 
+ );
+
+Similar to C<download> above, but for the C<extract> phase.
+
+=cut
+
+has 'extract';
+
 sub init
 {
   my($self, $meta) = @_;
@@ -121,6 +140,21 @@ sub init
       },
     );
   }
+
+  if(my $extract = $self->extract)
+  {
+    $extract = { 
+      'foo-1.00' => {
+        'configure' => _tarball_configure(),
+        'foo.c'     => _tarball_foo_c(),
+      },
+    } unless ref $extract eq 'HASH';
+    $meta->register_hook(
+      extract => sub {
+        _fs($extract);
+      },
+    );
+  }
 }
 
 sub _fs
@@ -152,6 +186,23 @@ M(;T=6(%BQIDFQB$V(8WB^]X.W>%WQ^[?_S'5,Z']\%]YU]IN#/KT/8[ZO^6?
 M_B=-C-=<%$BG'^4G_]S_U:)ZL*X:#(!6QN/26(Q&![W<P5_/EIF?*?])E&J>
 M'BD/DO/#^6<DON__6O*<_]]@99WJQ[W&FR'NK2_-+8!U$1X;ZRZ2P"9T:HW*
 D-`&ODGZZN[^$9T`,.H[!(>W@)2^*3":3.3]>`:%LBYL`#@``
+`
+EOF
+}
+
+sub _tarball_configure
+{
+  return unpack 'u', <<'EOF';
+<(R$O8FEN+W-H"@IE8VAO(")H:2!T:&5R92(["@``
+`
+EOF
+}
+
+sub _tarball_foo_c
+{
+  return unpack 'u', <<'EOF';
+M(VEN8VQU9&4@/'-T9&EO+F@^"@II;G0*;6%I;BAI;G0@87)G8RP@8VAA<B`J
+887)G=EM=*0I["B`@<F5T=7)N(#`["GT*
 `
 EOF
 }

--- a/lib/Alien/Build/Plugin/Test/Mock.pm
+++ b/lib/Alien/Build/Plugin/Test/Mock.pm
@@ -1,0 +1,82 @@
+package Alien::Build::Plugin::Test::Mock;
+
+use strict;
+use warnings;
+use Alien::Build::Plugin;
+use Carp ();
+
+=head1 SYNOPSIS
+
+ use alienfile;
+ plugin 'Test::Mock';
+
+=head1 DESCRIPTION
+
+This plugin is used for testing L<Alien::Build> plugins.  Usually you only want to test
+one or two phases in an L<alienfile> for your plugin, but you still have to have a fully
+formed L<alienfile> that contains all required phases.  This plugin lets you fill in the
+other phases with the appropriate hooks.  This is usually better than using real plugins
+which may pull in additional dynamic requirements that you do not want to rely on at
+test time.
+
+=head1 PROPERTIES
+
+=head2 probe
+
+ plugin 'Test::Mock' => (
+   probe => $probe,
+ );
+
+Override the probe behavior by one of the following:
+
+=over
+
+=item share
+
+For a C<share> build.
+
+=item system
+
+For a C<system> build.
+
+=item die
+
+To throw an exception in the probe hook.  This will usually cause L<Alien::Build>
+to try the next probe hook, if available, or to assume a C<share> install.
+
+=back
+
+=cut
+
+has 'probe';
+
+sub init
+{
+  my($self, $meta) = @_;
+  
+  if(my $probe = $self->probe)
+  {
+    if($probe =~ /^(share|system)$/)
+    {
+      $meta->register_hook(
+        probe => sub {
+          $probe;
+        },
+      );
+    }
+    elsif($probe eq 'die')
+    {
+      $meta->register_hook(
+        probe => sub {
+          die "fail";
+        },
+      );
+    }
+    else
+    {
+      Carp::croak("usage: plugin 'Test::Mock' => ( probe => $probe ); where $probe is one of share, system or die");
+    }
+  }
+}
+
+1;

--- a/t/01_use.t
+++ b/t/01_use.t
@@ -50,6 +50,7 @@ require_ok 'Alien::Build::Plugin::Prefer::GoodVersion';
 require_ok 'Alien::Build::Plugin::Prefer::SortVersions';
 require_ok 'Alien::Build::Plugin::Probe::CBuilder';
 require_ok 'Alien::Build::Plugin::Probe::CommandLine';
+require_ok 'Alien::Build::Plugin::Test::Mock';
 require_ok 'Alien::Build::Util';
 require_ok 'Alien::Build::Version::Basic';
 require_ok 'Alien::Role';
@@ -108,6 +109,7 @@ ok -f 't/alien_build_plugin_prefer_goodversion.t',            'test for Alien::B
 ok -f 't/alien_build_plugin_prefer_sortversions.t',           'test for Alien::Build::Plugin::Prefer::SortVersions';
 ok -f 't/alien_build_plugin_probe_cbuilder.t',                'test for Alien::Build::Plugin::Probe::CBuilder';
 ok -f 't/alien_build_plugin_probe_commandline.t',             'test for Alien::Build::Plugin::Probe::CommandLine';
+ok -f 't/alien_build_plugin_test_mock.t',                     'test for Alien::Build::Plugin::Test::Mock';
 ok -f 't/alien_build_util.t',                                 'test for Alien::Build::Util';
 ok -f 't/alien_build_version_basic.t',                        'test for Alien::Build::Version::Basic';
 ok -f 't/alien_role.t',                                       'test for Alien::Role';

--- a/t/alien_build_plugin_test_mock.t
+++ b/t/alien_build_plugin_test_mock.t
@@ -1,0 +1,55 @@
+use Test2::V0 -no_srand => 1;
+use Test::Alien::Build;
+use Alien::Build::Plugin::Test::Mock;
+
+subtest 'basic' => sub {
+  alienfile_ok q{
+    use alienfile;
+    plugin 'Test::Mock';
+  };
+};
+
+subtest 'probe' => sub {
+
+  subtest 'share' => sub {
+  
+    alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        'probe' => 'share'
+      );
+    };
+    
+    alien_install_type_is 'share';
+  
+  };
+
+  subtest 'share' => sub {
+  
+    alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        'probe' => 'system'
+      );
+    };
+    
+    alien_install_type_is 'system';
+  
+  };
+
+  subtest 'share' => sub {
+  
+    alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        'probe' => 'die'
+      );
+    };
+    
+    alien_install_type_is 'share';
+  
+  };
+
+};
+
+done_testing;

--- a/t/alien_build_plugin_test_mock.t
+++ b/t/alien_build_plugin_test_mock.t
@@ -142,7 +142,7 @@ subtest 'extract' => sub {
       $dir,
       object {
         call basename => 'bar-1.00';
-        call_list children => [ map { object { call basename => $_ } } sort qw( one two three ) ];
+        call_list sub { sort shift->children } => [ map { object { call basename => $_ } } sort qw( one two three ) ];
         call [ child => 'one' ] => object { call slurp => 1 };
         call [ child => 'two' ] => object { call slurp => 2 };
         call [ child => 'three' ] => object { call slurp => 3 };
@@ -168,17 +168,17 @@ subtest 'build' => sub {
     is(
       path($build->install_prop->{_ab_build_share}),
       object {
-        call_list children => [ map { object { call basename => $_ } } sort qw( configure foo.c foo.o libfoo.a ) ];
+        call_list sub { sort shift->children } => [ map { object { call basename => $_ } } sort qw( configure foo.c foo.o libfoo.a ) ];
       },
     );
     is(
       path($build->install_prop->{prefix}),
       object {
-        call_list children => [ map { object { call basename => $_ } } sort qw( _alien lib ) ];
+        call_list sub { sort shift->children } => [ map { object { call basename => $_ } } sort qw( _alien lib ) ];
         call [ child => 'lib' ] => object {
-          call_list children => [ map { object { call basename => $_ } } sort qw( libfoo.a pkgconfig ) ];
+          call_list sub { sort shift->children } => [ map { object { call basename => $_ } } sort qw( libfoo.a pkgconfig ) ];
           call [ child => 'pkgconfig' ] => object {
-            call_list children => [ map { object { call basename => $_ } } sort qw( foo.pc ) ];
+            call_list sub { sort shift->children } => [ map { object { call basename => $_ } } sort qw( foo.pc ) ];
             call [ child => 'foo.pc' ] => object {
               call slurp => match qr/-lfoo/;
             };
@@ -209,7 +209,7 @@ subtest 'build' => sub {
     is(
       path($build->install_prop->{_ab_build_share}),
       object {
-        call_list children => [ map { object { call basename => $_ } } sort qw( file1 configure foo.c ) ];
+        call_list sub { sort shift->children } => [ map { object { call basename => $_ } } sort qw( file1 configure foo.c ) ];
         call [ child => 'file1' ] => object {
           call slurp => 'content1';
         };
@@ -218,14 +218,72 @@ subtest 'build' => sub {
     is(
       path($build->install_prop->{prefix}),
       object {
-        call_list children => [ map { object { call basename => $_ } } sort qw( _alien file2 ) ];
+        call_list sub { sort shift->children } => [ map { object { call basename => $_ } } sort qw( _alien file2 ) ];
         call [ child => 'file2' ] => object {
           call slurp => 'content2';
         };
       },
     );
   };
+};
 
+subtest 'gather' => sub {
+  foreach my $install_type (qw( share system ))
+  {
+
+    subtest $install_type => sub {
+      subtest 'default' => sub {
+        my $build = alienfile_ok q{
+          use alienfile;
+          plugin 'Test::Mock' => (
+            download => 1,
+            extract  => 1,
+            build    => 1,
+            gather   => 1,
+          );
+        };
+        $build->meta->register_hook(probe => sub { $install_type });
+        alien_install_type_is $install_type;
+        alien_build_ok;
+        is(
+          $build->runtime_prop,
+          hash {
+            field cflags => match qr/^-I/;
+            field libs   => match qr/^-L.*-lfoo$/;
+            etc;
+          },
+        );
+        note "cflags = @{[ $build->runtime_prop->{cflags} ]}";
+        note "libs = @{[ $build->runtime_prop->{libs} ]}";
+      };
+    };
+
+    subtest $install_type => sub {
+      subtest 'override' => sub {
+        my $build = alienfile_ok q{
+          use alienfile;
+          plugin 'Test::Mock' => (
+            download => 1,
+            extract  => 1,
+            build    => 1,
+            gather   => { cflags => '-I/foo/include', libs => '-L/foo/lib -lfoo' },
+          );
+        };
+        $build->meta->register_hook(probe => sub { $install_type });
+        alien_install_type_is $install_type;
+        alien_build_ok;
+        is(
+          $build->runtime_prop,
+          hash {
+            field cflags => '-I/foo/include';
+            field libs   => '-L/foo/lib -lfoo';
+            etc;
+          },
+        );
+      };
+    };
+
+  };
 };
 
 done_testing;

--- a/t/alien_build_plugin_test_mock.t
+++ b/t/alien_build_plugin_test_mock.t
@@ -142,9 +142,86 @@ subtest 'extract' => sub {
       $dir,
       object {
         call basename => 'bar-1.00';
+        call_list children => [ map { object { call basename => $_ } } sort qw( one two three ) ];
         call [ child => 'one' ] => object { call slurp => 1 };
         call [ child => 'two' ] => object { call slurp => 2 };
         call [ child => 'three' ] => object { call slurp => 3 };
+      },
+    );
+  };
+
+};
+
+subtest 'build' => sub {
+
+  subtest 'default' => sub {
+    my $build = alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        probe => 'share',
+        download => 1,
+        extract => 1,
+        build => 1,
+      );
+    };
+    alien_build_ok;
+    is(
+      path($build->install_prop->{_ab_build_share}),
+      object {
+        call_list children => [ map { object { call basename => $_ } } sort qw( configure foo.c foo.o libfoo.a ) ];
+      },
+    );
+    is(
+      path($build->install_prop->{prefix}),
+      object {
+        call_list children => [ map { object { call basename => $_ } } sort qw( _alien lib ) ];
+        call [ child => 'lib' ] => object {
+          call_list children => [ map { object { call basename => $_ } } sort qw( libfoo.a pkgconfig ) ];
+          call [ child => 'pkgconfig' ] => object {
+            call_list children => [ map { object { call basename => $_ } } sort qw( foo.pc ) ];
+            call [ child => 'foo.pc' ] => object {
+              call slurp => match qr/-lfoo/;
+            };
+          };
+        };
+      },
+    );
+  };
+
+  subtest 'override' => sub {
+    my $build = alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        probe => 'share',
+        download => 1,
+        extract => 1,
+        build => [
+          {
+            file1 => 'content1',
+          },
+          {
+            file2 => 'content2',
+          },
+        ],
+      );
+    };
+    alien_build_ok;
+    is(
+      path($build->install_prop->{_ab_build_share}),
+      object {
+        call_list children => [ map { object { call basename => $_ } } sort qw( file1 configure foo.c ) ];
+        call [ child => 'file1' ] => object {
+          call slurp => 'content1';
+        };
+      },
+    );
+    is(
+      path($build->install_prop->{prefix}),
+      object {
+        call_list children => [ map { object { call basename => $_ } } sort qw( _alien file2 ) ];
+        call [ child => 'file2' ] => object {
+          call slurp => 'content2';
+        };
       },
     );
   };

--- a/t/alien_build_plugin_test_mock.t
+++ b/t/alien_build_plugin_test_mock.t
@@ -94,4 +94,61 @@ subtest 'download' => sub {
 
 };
 
+subtest 'extract' => sub {
+
+  subtest 'default' => sub {
+    my $build = alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        probe => 'share',
+        download => 1,
+        extract => 1,
+      );
+    };
+    alien_extract_ok;
+    my $dir = path($build->install_prop->{extract});
+    is(
+      $dir,
+      object {
+        call basename => 'foo-1.00';
+        call [child => 'configure' ] => object {
+          call slurp => path('corpus/dist/foo-1.00/configure')->slurp;
+        };
+        call [child => 'foo.c' ] => object {
+          call slurp => path('corpus/dist/foo-1.00/foo.c')->slurp;
+        };
+      },
+    );
+  };
+
+  subtest 'override' => sub {
+    my $build = alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        probe => 'share',
+        download => 1,
+        extract => {
+          'bar-1.00' => {
+            one => 1,
+            two => 2,
+            three => 3,
+          },
+        },
+      );
+    };
+    alien_extract_ok;
+    my $dir = path($build->install_prop->{extract});
+    is(
+      $dir,
+      object {
+        call basename => 'bar-1.00';
+        call [ child => 'one' ] => object { call slurp => 1 };
+        call [ child => 'two' ] => object { call slurp => 2 };
+        call [ child => 'three' ] => object { call slurp => 3 };
+      },
+    );
+  };
+
+};
+
 done_testing;

--- a/t/alien_build_plugin_test_mock.t
+++ b/t/alien_build_plugin_test_mock.t
@@ -1,6 +1,7 @@
 use Test2::V0 -no_srand => 1;
 use Test::Alien::Build;
 use Alien::Build::Plugin::Test::Mock;
+use Path::Tiny qw( path );
 
 subtest 'basic' => sub {
   alienfile_ok q{
@@ -48,6 +49,47 @@ subtest 'probe' => sub {
     
     alien_install_type_is 'share';
   
+  };
+
+};
+
+subtest 'download' => sub {
+
+  subtest 'default' => sub {
+    my $build = alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        probe => 'share',
+        download => 1,
+      );
+    };
+    alien_download_ok;
+    my $tarball = path($build->install_prop->{download});
+    is(
+      $tarball,
+      object {
+        call basename => 'foo-1.00.tar.gz';
+        call slurp => path('corpus/dist/foo-1.00.tar.gz')->slurp;
+      },
+    );
+  };
+
+  subtest 'override' => sub {
+    my $build = alienfile_ok q{
+      use alienfile;
+      plugin 'Test::Mock' => (
+        download => { 'bar-1.00.tar.gz' => 'fauxtar' },
+      );
+    };
+    alien_download_ok;
+    my $tarball = path($build->install_prop->{download});
+    is(
+      $tarball,
+      object {
+        call basename => 'bar-1.00.tar.gz';
+        call slurp => 'fauxtar';
+      },
+    );
   };
 
 };

--- a/t/test_alien_build.t
+++ b/t/test_alien_build.t
@@ -693,4 +693,34 @@ subtest 'targ' => sub {
 
 };
 
+alien_subtest 'alienfile_ok takes a already formed Alien::Build instance' => sub {
+
+  my $build = alienfile q{ use alienfile };
+  
+  is(
+    intercept { alienfile_ok $build },
+    array {
+      event Ok => sub {
+        call pass => T();
+        call name => 'alienfile compiled';
+      };
+      end;
+    },
+  );
+  
+  is(
+    intercept { alienfile_ok undef },
+    array {
+      event Ok => sub {
+        call pass => F();
+        call name => 'alienfile compiled';
+      };
+      event Diag => sub {};
+      event Diag => sub { call message => 'error: no alienfile given' };
+      end;
+    },
+  );
+
+};
+
 done_testing;

--- a/t/test_alien_canplatypus.t
+++ b/t/test_alien_canplatypus.t
@@ -22,6 +22,8 @@ subtest 'skip/import' => sub {
 
   subtest 'no platypus' => sub {
 
+    $Devel::Hide::VERBOSE =
+    $Devel::Hide::VERBOSE = 0;
     skip_all 'test does not work on Perl 5.8' unless $] >= 5.010;
     skip_all 'subtest requires Devel::Hide' unless eval { require Devel::Hide };
     Devel::Hide->import( 'FFI::Platypus' );


### PR DESCRIPTION
This PR will address #64 and #65.  The idea is to improve the testing of `Alien::Build` plugins.  Progress:

  - [x] Test::Mock plugin that makes it easy to mock the phases in an alienfile that your plugin isn't addressing (for example, download/extract when you are writing a build plugin).
  - [x] skip_all_if_alienfile_missing_prereqs (would love a better name than that), that skips the test or subtest if you are missing `share` or `system` prereqs for a particular alienfile.  Thus you can test a plugin interaction when its prereqs are installed, but do not have to require them when they aren't needed by system integrators
  - [ ] At least some of the core AB tests should be refactored to use these tools.  There are lots of candidates, there are probably too many to do all of them at least right away.