### PR TITLE
Add lib64/pkgconfig to PKG_CONFIG_PATH

### DIFF
--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -868,7 +868,7 @@ sub load_requires
     if(($mod->can('runtime_prop') && $mod->runtime_prop)
     || ($mod->isa('Alien::Base')  && $mod->install_type('share')))
     {
-      for my $dir (qw(lib share)) {
+      for my $dir (qw(lib64 lib share)) {
           my $path = _path($mod->dist_dir)->child("$dir/pkgconfig");
           if(-d $path)
           {

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -161,7 +161,7 @@ sub init
       {
         my $real_prefix = Path::Tiny->new($build->install_prop->{prefix});
         my @pkgconf_dirs;
-        push @pkgconf_dirs, Path::Tiny->new($ENV{DESTDIR})->child($prefix)->child("$_/pkgconfig") for qw(lib share);
+        push @pkgconf_dirs, Path::Tiny->new($ENV{DESTDIR})->child($prefix)->child("$_/pkgconfig") for qw(lib64 lib share);
       
         # for any pkg-config style .pc files that are dropped, we need
         # to convert the MSYS /C/Foo style paths to C:/Foo

--- a/lib/Alien/Build/Plugin/Core/Gather.pm
+++ b/lib/Alien/Build/Plugin/Core/Gather.pm
@@ -44,7 +44,7 @@ sub init
       unshift @PATH, Path::Tiny->new('bin')->absolute->stringify
         if -d 'bin';
 
-      for my $dir (qw(share lib)) {
+      for my $dir (qw(share lib lib64)) {
           unshift @PKG_CONFIG_PATH, Path::Tiny->new("$dir/pkgconfig")->absolute->stringify
             if -d "$dir/pkgconfig";
       }


### PR DESCRIPTION
pkg-config(1) now searches in {lib64,lib,share}/pkgconfig.
Adding lib64 is necessary because otherwise we might
not gather all *.pc files, as e.g. Fedora 28 has:

	[root@f28 ~]# pkg-config --variable=pc_path pkg-config
	/usr/lib64/pkgconfig:/usr/share/pkgconfig

This PR addresses issues unveiled by @eserte's CPAN testing, e.g.: https://github.com/athreef/Alien-libpid/issues/1
