### PR TITLE
Add some version comparison methods to Alien::Base (fixes #75)

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -396,21 +396,30 @@ sub atleast_version {
   my $self = shift;
   my ($wantver) = @_;
 
-  return $self->version_cmp($self->version, $wantver) >= 0;
+  defined(my $version = $self->version) or
+    croak "$self has no defined ->version";
+
+  return $self->version_cmp($version, $wantver) >= 0;
 }
 
 sub exact_version {
   my $self = shift;
   my ($wantver) = @_;
 
-  return $self->version_cmp($self->version, $wantver) == 0;
+  defined(my $version = $self->version) or
+    croak "$self has no defined ->version";
+
+  return $self->version_cmp($version, $wantver) == 0;
 }
 
 sub max_version {
   my $self = shift;
   my ($wantver) = @_;
 
-  return $self->version_cmp($self->version, $wantver) <= 0;
+  defined(my $version = $self->version) or
+    croak "$self has no defined ->version";
+
+  return $self->version_cmp($version, $wantver) <= 0;
 }
 
 =head2 install_type

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -365,7 +365,8 @@ sub version {
 # Sort::Versions isn't quite the same algorithm because it differs in
 # behaviour with leading zeroes.
 #   See also  https://dev.gentoo.org/~mgorny/pkg-config-spec.html#version-comparison
-sub _versioncmp {
+sub version_cmp {
+  shift;
   my @x = (shift =~ m/([0-9]+|[a-z]+)/ig);
   my @y = (shift =~ m/([0-9]+|[a-z]+)/ig);
 
@@ -395,21 +396,21 @@ sub atleast_version {
   my $self = shift;
   my ($wantver) = @_;
 
-  return _versioncmp($self->version, $wantver) >= 0;
+  return $self->version_cmp($self->version, $wantver) >= 0;
 }
 
 sub exact_version {
   my $self = shift;
   my ($wantver) = @_;
 
-  return _versioncmp($self->version, $wantver) == 0;
+  return $self->version_cmp($self->version, $wantver) == 0;
 }
 
 sub max_version {
   my $self = shift;
   my ($wantver) = @_;
 
-  return _versioncmp($self->version, $wantver) <= 0;
+  return $self->version_cmp($self->version, $wantver) <= 0;
 }
 
 =head2 install_type

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -392,6 +392,21 @@ sub version_cmp {
   return @x <=> @y;
 }
 
+=head2 atleast_version
+
+=head2 exact_version
+
+=head2 max_version
+
+ my $ok = Alien::MyLibrary->atleast_version($wanted_version)
+ my $ok = Alien::MyLibrary->exact_version($wanted_version)
+ my $ok = Alien::MyLibrary->max_version($wanted_version)
+
+Returns true if the version of the alienized library or tool is at least,
+exactly, or at most the version specified, respectively.
+
+=cut
+
 sub atleast_version {
   my $self = shift;
   my ($wantver) = @_;

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -398,9 +398,9 @@ sub version_cmp {
 
 =head2 max_version
 
- my $ok = Alien::MyLibrary->atleast_version($wanted_version)
- my $ok = Alien::MyLibrary->exact_version($wanted_version)
- my $ok = Alien::MyLibrary->max_version($wanted_version)
+ my $ok = Alien::MyLibrary->atleast_version($wanted_version);
+ my $ok = Alien::MyLibrary->exact_version($wanted_version);
+ my $ok = Alien::MyLibrary->max_version($wanted_version);
 
 Returns true if the version of the alienized library or tool is at least,
 exactly, or at most the version specified, respectively.

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -362,36 +362,6 @@ sub version {
     };
 }
 
-# Sort::Versions isn't quite the same algorithm because it differs in
-# behaviour with leading zeroes.
-#   See also  https://dev.gentoo.org/~mgorny/pkg-config-spec.html#version-comparison
-sub version_cmp {
-  shift;
-  my @x = (shift =~ m/([0-9]+|[a-z]+)/ig);
-  my @y = (shift =~ m/([0-9]+|[a-z]+)/ig);
-
-  while(@x and @y) {
-    my $x = shift @x; my $x_isnum = $x =~ m/[0-9]/;
-    my $y = shift @y; my $y_isnum = $y =~ m/[0-9]/;
-
-    if($x_isnum and $y_isnum) {
-      # Numerical comparison
-      return $x <=> $y if $x != $y;
-    }
-    elsif(!$x_isnum and !$y_isnum) {
-      # Alphabetic comparison
-      return $x cmp $y if $x ne $y;
-    }
-    else {
-      # Of differing types, the numeric one is newer
-      return $x_isnum - $y_isnum;
-    }
-  }
-
-  # Equal so far; the longer is newer
-  return @x <=> @y;
-}
-
 =head2 atleast_version
 
 =head2 exact_version
@@ -435,6 +405,51 @@ sub max_version {
     croak "$self has no defined ->version";
 
   return $self->version_cmp($version, $wantver) <= 0;
+}
+
+=head2 version_cmp
+
+  $cmp = Alien::MyLibrary->version_cmp($x, $y)
+
+Comparison method used by L<atleast_version>, L<exact_version> and
+L<max_version>. May be useful to implement custom comparisons, or for
+subclasses to overload to get different version comparison semantics than the
+default rules, for packages that have some other rules than the F<pkg-config>
+behaviour.
+
+Should return a number less than, equal to, or greater than zero; similar in
+behaviour to the C<< <=> >> and C<cmp> operators.
+
+=cut
+
+# Sort::Versions isn't quite the same algorithm because it differs in
+# behaviour with leading zeroes.
+#   See also  https://dev.gentoo.org/~mgorny/pkg-config-spec.html#version-comparison
+sub version_cmp {
+  shift;
+  my @x = (shift =~ m/([0-9]+|[a-z]+)/ig);
+  my @y = (shift =~ m/([0-9]+|[a-z]+)/ig);
+
+  while(@x and @y) {
+    my $x = shift @x; my $x_isnum = $x =~ m/[0-9]/;
+    my $y = shift @y; my $y_isnum = $y =~ m/[0-9]/;
+
+    if($x_isnum and $y_isnum) {
+      # Numerical comparison
+      return $x <=> $y if $x != $y;
+    }
+    elsif(!$x_isnum and !$y_isnum) {
+      # Alphabetic comparison
+      return $x cmp $y if $x ne $y;
+    }
+    else {
+      # Of differing types, the numeric one is newer
+      return $x_isnum - $y_isnum;
+    }
+  }
+
+  # Equal so far; the longer is newer
+  return @x <=> @y;
 }
 
 =head2 install_type

--- a/t/alien_base.t
+++ b/t/alien_base.t
@@ -125,6 +125,22 @@ subtest 'Alien::Build system' => sub {
   is( [Alien::libfoo1->bin_dir], [], 'bin_dir' );
   
   is( Alien::libfoo1->runtime_prop->{arbitrary}, 'one', 'runtime_prop' );
+
+  {
+    # no version
+    my $mock = mock 'Alien::libfoo1' => (
+      override => [
+        version => sub { return undef },
+      ],
+    );
+
+    ok( !eval{ Alien::libfoo1->atleast_version('1.2'); 1 } and
+        $@ =~ m/has no defined ->version/, 'no version atleast' );
+    ok( !eval { Alien::libfoo1->exact_version('1.2.3'); 1 } and
+        $@ =~ m/has no defined ->version/, 'no version exactly' );
+    ok( !eval { Alien::libfoo1->max_version('1.4'); 1 } and
+        $@ =~ m/has no defined ->version/, 'no version atmost' );
+  }
 };
 
 subtest 'Alien::Build quazi system dylib' => sub {

--- a/t/alien_base.t
+++ b/t/alien_base.t
@@ -106,10 +106,10 @@ subtest 'Alien::Build system' => sub {
   is( Alien::libfoo1->libs, '-lfoo', 'libs' );
   is( Alien::libfoo1->libs_static, '-lfoo -lbar -lbaz', 'libs_static' );
   is( Alien::libfoo1->version, '1.2.3', 'version');
-  ok( Alien::libfoo1->atleast_version( '1.2' ), 'version atleast 1.2' );
-  ok( !Alien::libfoo1->atleast_version( '1.3' ), 'version not atleast 1.3' );
-  ok( Alien::libfoo1->exact_version( '1.2.3' ), 'version exactly 1.2.3' );
-  ok( Alien::libfoo1->max_version( '1.4' ), 'version atmost 1.4' );
+  ok( Alien::libfoo1->atleast_version('1.2'), 'version atleast 1.2' );
+  ok( !Alien::libfoo1->atleast_version('1.3'), 'version not atleast 1.3' );
+  ok( Alien::libfoo1->exact_version('1.2.3'), 'version exactly 1.2.3' );
+  ok( Alien::libfoo1->max_version('1.4'), 'version atmost 1.4' );
   
   subtest 'install type' => sub {
     is( Alien::libfoo1->install_type, 'system' );

--- a/t/alien_base.t
+++ b/t/alien_base.t
@@ -106,6 +106,10 @@ subtest 'Alien::Build system' => sub {
   is( Alien::libfoo1->libs, '-lfoo', 'libs' );
   is( Alien::libfoo1->libs_static, '-lfoo -lbar -lbaz', 'libs_static' );
   is( Alien::libfoo1->version, '1.2.3', 'version');
+  ok( Alien::libfoo1->atleast_version( '1.2' ), 'version atleast 1.2' );
+  ok( !Alien::libfoo1->atleast_version( '1.3' ), 'version not atleast 1.3' );
+  ok( Alien::libfoo1->exact_version( '1.2.3' ), 'version exactly 1.2.3' );
+  ok( Alien::libfoo1->max_version( '1.4' ), 'version atmost 1.4' );
   
   subtest 'install type' => sub {
     is( Alien::libfoo1->install_type, 'system' );


### PR DESCRIPTION
Currently slightly in process. One thing still TODO:

 * Does ->version_cmp need documenting, so subclass authors know how they can override it?