### PR TITLE
more relaxed diagnostic testing for haiku

### DIFF
--- a/t/test_alien_run.t
+++ b/t/test_alien_run.t
@@ -359,7 +359,14 @@ subtest 'run with kill 9' => sub {
         call message => "  using $^X";
       };
       event Diag => sub {
-        call message => "  killed with signal: 9";
+        if($^O eq 'haiku')
+        {
+          call message => match qr/^  killed with signal: (9|21)$/;
+        }
+        else
+        {
+          call message => "  killed with signal: 9";
+        }
       };
       end;
     },
@@ -369,7 +376,14 @@ subtest 'run with kill 9' => sub {
   is $run->out, '', 'output';
   is $run->err, '', 'error';
   is $run->exit, 0, 'exit';
-  is $run->signal, 9, 'signal';
+  if($^O eq 'haiku')
+  {
+    like $run->signal, qr/^(9|21)$/, 'signal';
+  }
+  else
+  {
+    is $run->signal, 9, 'signal';
+  }
 
   is(
     intercept { $run->success },
@@ -380,7 +394,14 @@ subtest 'run with kill 9' => sub {
       };
       event Diag => sub {};
       event Diag => sub {
-        call message => '  command killed with 9';
+        if($^O eq 'haiku')
+        {
+          call message => match qr/^  command killed with (9|21)$/;
+        }
+        else
+        {
+          call message => "  command killed with 9";
+        }
       };
       end;
     },


### PR DESCRIPTION
This is the only fail from a cpantest report on haiku:

```
t/test_alien_canplatypus.t ........................... ok
    # Failed test 'run_ok'
    # at t/test_alien_run.t line 366.
    # +----------------+-----+----------------+----+----------------+----------+
    # | PATH           | LNs | GOT            | OP | CHECK          | LNs      |
    # +----------------+-----+----------------+----+----------------+----------+
    # |                |     | ARRAY(0x192cbd |    | <ARRAY>        | 355, 365 |
    # |                |     | 0d6d8)         |    |                |          |
    # |                |     |                |    |                |          |
    # | [3]            | 351 | Test2::Event:: |    | <EVENT: Diag>  | 362, 362 |
    # |                |     | Diag=HASH(0x19 |    |                |          |
    # |                |     | 2ca874400)     |    |                |          |
    # |                |     |                |    |                |          |
    # | [3]->message() |     |   killed with  | eq |   killed with  | 462      |
    # |                |     | signal: 21     |    | signal: 9      |          |
    # +----------------+-----+----------------+----+----------------+----------+
    # Failed test 'signal'
    # at t/test_alien_run.t line 372.
    # +-----+----+-------+
    # | GOT | OP | CHECK |
    # +-----+----+-------+
    # | 21  | eq | 9     |
    # +-----+----+-------+
    # Failed test 'run.success'
    # at t/test_alien_run.t line 387.
    # +----------------+-----+----------------+----+----------------+----------+
    # | PATH           | LNs | GOT            | OP | CHECK          | LNs      |
    # +----------------+-----+----------------+----+----------------+----------+
    # |                |     | ARRAY(0x192cbd |    | <ARRAY>        | 379, 386 |
    # |                |     | 06378)         |    |                |          |
    # |                |     |                |    |                |          |
    # | [2]            | 375 | Test2::Event:: |    | <EVENT: Diag>  | 383, 383 |
    # |                |     | Diag=HASH(0x19 |    |                |          |
    # |                |     | 2cbcf2c58)     |    |                |          |
    # |                |     |                |    |                |          |
    # | [2]->message() |     |   command kill | eq |   command kill | 462      |
    # |                |     | ed with 21     |    | ed with 9      |          |
    # +----------------+-----+----------------+----+----------------+----------+

# Failed test 'run with kill 9'
# at t/test_alien_run.t line 390.
t/test_alien_run.t ................................... 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/5 subtests 
```

http://www.cpantesters.org/cpan/report/79b969fc-2ef2-11e9-b46c-d3780df0180e

The diagnostic might be wrong, but it doesn't seem that important, so relax the test a little on haiku.