### PR TITLE
check tmpdir

### DIFF
--- a/inc/probebad.pl
+++ b/inc/probebad.pl
@@ -2,6 +2,8 @@ use strict;
 use warnings;
 use ExtUtils::CBuilder;
 use ExtUtils::ParseXS;
+use File::Temp qw( tempdir );
+use File::Spec;
 
 # probebad.pl: this is intended to be run by Makefile.PL to find FAIL reports
 # that commonly come from cpantesters, but are in fact the result of badly
@@ -9,70 +11,84 @@ use ExtUtils::ParseXS;
 # but sometimes they are either unable or unwilling to respond, and I don't
 # want to waste my time re-diagnosing the same errors.
 
-my $cb = ExtUtils::CBuilder->new;
+{ # /tmp check
+  my $dir = eval { tempdir( CLEANUP => 1 ) };
+  if($@)
+  {
+    print "Configuration unsupported\n";
+    print "Unable to create a temp directory using File::Temp.  This is used\n";
+    print "extensively by the test suite.  You may want to check if the dir\n";
+    print "@{[ File::Spec->tmpdir ]} is full or has other problems\n";
+    exit;
+  }
+}
 
-if($cb->have_compiler)
-{
-  my $pxs = ExtUtils::ParseXS->new;
-  eval {
-    $pxs->process_file(
-      filename     => "inc/trivial.xs",
-      output       => "inc/trivial.c",
-      versioncheck => 0,
-      prototypes   => 0,
+{ # compiler checks
+  my $cb = ExtUtils::CBuilder->new;
+
+  if($cb->have_compiler)
+  {
+    my $pxs = ExtUtils::ParseXS->new;
+    eval {
+      $pxs->process_file(
+        filename     => "inc/trivial.xs",
+        output       => "inc/trivial.c",
+        versioncheck => 0,
+        prototypes   => 0,
+      );
+    };
+
+    if(my $error = $@)
+    {
+      print "Configuration unsupported\n";
+      print "You appear to have a C compiler, but I am unable to process a\n";
+      print "trivial XS file, errored with:\n";
+      print "$error\n";
+      exit;
+    }
+  
+    if($pxs->report_error_count != 0)
+    {
+      print "Configuration unsupported\n";
+      print "You appear to have a C compiler, but there were errors processing\n";
+      print "a trivial XS file.\n";
+      exit;
+    }
+  
+    my($cc_out, $obj, $cc_exception) = capture_merged(
+      sub {
+        my $obj = eval {
+          $cb->compile(
+            source => "inc/trivial.c",
+          );
+        };
+        ($obj, $@);
+      }
     );
-  };
-
-  if(my $error = $@)
-  {
-    print "Configuration unsupported\n";
-    print "You appear to have a C compiler, but I am unable to process a\n";
-    print "trivial XS file, errored with:\n";
-    print "$error\n";
-    exit;
-  }
   
-  if($pxs->report_error_count != 0)
-  {
-    print "Configuration unsupported\n";
-    print "You appear to have a C compiler, but there were errors processing\n";
-    print "a trivial XS file.\n";
-    exit;
-  }
-  
-  my($cc_out, $obj, $cc_exception) = capture_merged(
-    sub {
-      my $obj = eval {
-        $cb->compile(
-          source => "inc/trivial.c",
-        );
-      };
-      ($obj, $@);
-    }
-  );
-  
-  if(! $obj)
-  {
-    print "Configuration unsupported\n";
-    print "You appear to have a C compiler, but there were errors processing\n";
-    print "the C file generated from a trivial XS file.\n";
-    if($cc_exception)
+    if(! $obj)
     {
-      print "Exception:\n";
-      print "$cc_exception\n";
+      print "Configuration unsupported\n";
+      print "You appear to have a C compiler, but there were errors processing\n";
+      print "the C file generated from a trivial XS file.\n";
+      if($cc_exception)
+      {
+        print "Exception:\n";
+        print "$cc_exception\n";
+      }
+      if($cc_out)
+      {
+        print "Compiler output:\n";
+        print "$cc_out\n";
+      }
+      exit;
     }
-    if($cc_out)
-    {
-      print "Compiler output:\n";
-      print "$cc_out\n";
-    }
-    exit;
-  }
   
-  # cleanup
-  unlink 'inc/trivial.c';
-  unlink $obj;
+    # cleanup
+    unlink 'inc/trivial.c';
+    unlink $obj;
 
+  }
 }
 
 sub capture_merged


### PR DESCRIPTION
These reports from ct are annoying:

```
t/01_use.t ........................................... ok
t/alien_base.t ....................................... ok
t/alien_base__system_installed.t ..................... skipped: test requires Alien::Base::ModuleBuild
t/alien_base_pkgconfig.t ............................. ok
t/alien_base_wrapper.t ............................... ok
        # Failed test 'alienfile compiles'
        # at t/alien_build.t line 1566.
        # error: mkpath failed for /tmp/1m2HNoso6s/prefix: No space left on device at /home/david/cpantesting/perl-5.8.9/.cpan/build/Alien-Build-1.60-0/blib/lib/Test/Alien/Build.pm line 61.
    # Failed test 'share'
    # at t/alien_build.t line 1579.
    # Caught exception in subtest: Error in tempfile() using template /tmp/XXXXXXXXXX: Could not create temp file /tmp/vYSkBNHtbg: No space left on device at /home/david/cpantesting/perl-5.8.9/lib/site_perl/5.8.9/Capture/Tiny.pm line 360.

# Failed test 'do not allow network install'
# at t/alien_build.t line 1586.
    # Failed test 'alienfile compiles'
    # at t/alien_build.t line 1594.
    # error: Error in tempfile() using template /tmp/XXXXXXXXXX: Could not create temp file /tmp/NEl9YZczPw: No space left on device at /home/david/cpantesting/perl-5.8.9/lib/site_perl/5.8.9/Capture/Tiny.pm line 360.
    # Failed test 'alien builds okay'
    # at t/alien_build.t line 1614.
    # no alienfile

# Failed test 'interpolate env overrides'
# at t/alien_build.t line 1616.
t/alien_build.t ...................................... 
Dubious, test returned 2 (wstat 512, 0x200)
```

check for this bad configuration and fail with exit 0 at configure time.