### PR TITLE
For Inline::C / ExtUtils::Depends: split INC flags off the rest of cflags

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -834,7 +834,8 @@ sub Inline {
   my ($class, $language) = @_;
   return if $language !~ /^(C|CPP)$/;
   my $config = {
-    CCFLAGSEX    => $class->cflags,
+    CCFLAGSEX    => join(' ', grep !/^-I/, shellwords($class->cflags)),
+    INC          => join(' ', grep  /^-I/, shellwords($class->cflags)),
     LIBS         => $class->libs,
   };
   


### PR DESCRIPTION
This will help with #107, although I think there may need to be some updates to EU::D as well.