### PR TITLE
Switch to using Decode::Mojo instead of Decode::HTML

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Download::Negotiate defaults to Deocde::Mojo instead of Decode::HTML for
+    share installs that require parsing an HTML index.
 
 1.74      2019-05-22 08:43:10 -0400
   - Check if share directory exists before clean_install

--- a/Changes
+++ b/Changes
@@ -2,7 +2,7 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
   - Download::Negotiate defaults to Deocde::Mojo instead of Decode::HTML for
-    share installs that require parsing an HTML index.
+    share installs that require parsing an HTML index (gh#127, gh#115).
 
 1.74      2019-05-22 08:43:10 -0400
   - Check if share directory exists before clean_install

--- a/lib/Alien/Build/Plugin/Decode/Mojo.pm
+++ b/lib/Alien/Build/Plugin/Decode/Mojo.pm
@@ -37,9 +37,9 @@ This plugin decodes an HTML file listing into a list of candidates for your Pref
 It works just like L<Alien::Build::Plugin::Decode::HTML> except it uses either L<Mojo::DOM>
 or L<Mojo::DOM58> to do its job.
 
-This plugin is much lighter than The C<Decode::HTML> plugin, and doesn't require XS.  The
-intent is if this plugin proves its self reliable that it will eventually be preferred by
-the download negotiator.
+This plugin is much lighter than The C<Decode::HTML> plugin, and doesn't require XS.  It
+is the default decode plugin used by L<Alien::Build::Plugin::Download::Negotiate> if it
+detects that you need to parse an HTML index.
 
 =cut
 

--- a/lib/Alien/Build/Plugin/Download/Negotiate.pm
+++ b/lib/Alien/Build/Plugin/Download/Negotiate.pm
@@ -175,32 +175,32 @@ sub _pick
   {
     if($self->bootstrap_ssl && ! _has_ssl)
     {
-      return (['Fetch::CurlCommand','Fetch::Wget'], 'Decode::HTML');
+      return (['Fetch::CurlCommand','Fetch::Wget'], 'Decode::Mojo');
     }
     elsif(_has_ssl)
     {
-      return ('Fetch::HTTPTiny', 'Decode::HTML');
+      return ('Fetch::HTTPTiny', 'Decode::Mojo');
     }
     elsif(do { require Alien::Build::Plugin::Fetch::CurlCommand; Alien::Build::Plugin::Fetch::CurlCommand->protocol_ok('https') })
     {
-      return ('Fetch::CurlCommand', 'Decode::HTML');
+      return ('Fetch::CurlCommand', 'Decode::Mojo');
     }
     else
     {
-      return ('Fetch::HTTPTiny', 'Decode::HTML');
+      return ('Fetch::HTTPTiny', 'Decode::Mojo');
     }
   }
   elsif($self->scheme eq 'http')
   {
-    return ('Fetch::HTTPTiny', 'Decode::HTML');
+    return ('Fetch::HTTPTiny', 'Decode::Mojo');
   }
   elsif($self->scheme eq 'ftp')
   {
     if($ENV{ftp_proxy} || $ENV{all_proxy})
     {
       return $self->scheme =~ /^ftps?/
-        ? ('Fetch::LWP', 'Decode::DirListing', 'Decode::HTML')
-        : ('Fetch::LWP', 'Decode::HTML');
+        ? ('Fetch::LWP', 'Decode::DirListing', 'Decode::Mojo')
+        : ('Fetch::LWP', 'Decode::Mojo');
     }
     else
     {

--- a/t/alien_build_plugin_download_negotiate.t
+++ b/t/alien_build_plugin_download_negotiate.t
@@ -33,7 +33,7 @@ subtest 'pick fetch' => sub {
 
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('http://mytest.test/');
 
-    is([$plugin->pick], ['Fetch::HTTPTiny','Decode::HTML']);
+    is([$plugin->pick], ['Fetch::HTTPTiny','Decode::Mojo']);
     is($plugin->scheme, 'http');
 
   };
@@ -75,7 +75,7 @@ subtest 'pick fetch' => sub {
 
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('https://mytest.test/');
 
-    is([$plugin->pick], ['Fetch::HTTPTiny','Decode::HTML']);
+    is([$plugin->pick], ['Fetch::HTTPTiny','Decode::Mojo']);
     is($plugin->scheme, 'https');
 
   };
@@ -87,7 +87,7 @@ subtest 'pick fetch' => sub {
 
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('https://mytest.test/');
 
-    is([$plugin->pick], ['Fetch::CurlCommand','Decode::HTML']);
+    is([$plugin->pick], ['Fetch::CurlCommand','Decode::Mojo']);
     is($plugin->scheme, 'https');
 
   };
@@ -99,7 +99,7 @@ subtest 'pick fetch' => sub {
 
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('https://mytest.test/');
 
-    is([$plugin->pick], ['Fetch::HTTPTiny','Decode::HTML']);
+    is([$plugin->pick], ['Fetch::HTTPTiny','Decode::Mojo']);
     is($plugin->scheme, 'https');
 
   };
@@ -119,7 +119,7 @@ subtest 'pick fetch' => sub {
 
     my $plugin = Alien::Build::Plugin::Download::Negotiate->new('ftp://mytest.test/');
 
-    is([$plugin->pick], ['Fetch::LWP','Decode::DirListing','Decode::HTML']);
+    is([$plugin->pick], ['Fetch::LWP','Decode::DirListing','Decode::Mojo']);
     is($plugin->scheme, 'ftp');
 
   };
@@ -162,7 +162,7 @@ subtest 'pick fetch' => sub {
         [$plugin->pick],
         array {
           item ['Fetch::CurlCommand','Fetch::Wget'];
-          item 'Decode::HTML';
+          item 'Decode::Mojo';
           end;
         },
       );
@@ -182,7 +182,7 @@ subtest 'pick fetch' => sub {
         [$plugin->pick],
         array {
           item 'Fetch::HTTPTiny';
-          item 'Decode::HTML';
+          item 'Decode::Mojo';
           end;
         },
       );
@@ -202,7 +202,7 @@ subtest 'pick fetch' => sub {
       [$plugin->pick],
       array {
         item 'Fetch::HTTPTiny';
-        item 'Decode::HTML';
+        item 'Decode::Mojo';
         end;
       },
     );

--- a/t/alien_build_plugin_fetch_curlcommand.t
+++ b/t/alien_build_plugin_fetch_curlcommand.t
@@ -219,7 +219,7 @@ subtest 'live test' => sub {
   my $mock = mock 'Alien::Build::Plugin::Download::Negotiate' => (
     override => [
       pick => sub {
-        ('Fetch::CurlCommand', 'Decode::HTML');
+        ('Fetch::CurlCommand', 'Decode::Mojo');
       },
     ],
   );


### PR DESCRIPTION
This makes the `Decode::Mojo` plugin the default for the download negotiator. #115