### PR TITLE
use ->canonical and ->ascii to make json dumps more reliable

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - _alien/alien.json file is generated using ->canonical(1) for reproducibility
+    (gh#132 Grinnz++ for the suggestion)
+  - _alien/alien.json file is generated using ->ascii to avoid warnings / errors
+    when unicode is included in install/runtime properties.
+    (gh#132 Grinnz++ for the suggestion)
 
 1.76      2019-06-23 11:01:08 -0400
   - Production release identical to 1.75_01

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -724,7 +724,7 @@ sub checkpoint
   my($self) = @_;
   my $root = $self->root;
   _path("$root/state.json")->spew(
-    JSON::PP->new->pretty->canonical(1)->encode({
+    JSON::PP->new->pretty->canonical(1)->ascii->encode({
       install => $self->install_prop,
       runtime => $self->runtime_prop,
       args    => $self->{args},

--- a/lib/Alien/Build/Plugin/Core/Gather.pm
+++ b/lib/Alien/Build/Plugin/Core/Gather.pm
@@ -126,7 +126,7 @@ sub init
       
       # drop a alien.json file for the runtime properties
       $stage->child('_alien/alien.json')->spew(
-        JSON::PP->new->pretty->encode($build->runtime_prop)
+        JSON::PP->new->pretty->canonical(1)->ascii->encode($build->runtime_prop)
       );
       
       # copy the alienfile, if we managed to keep it around.


### PR DESCRIPTION
->canonical(1) gives us a reproducible build.
->ascii will encode in an ascii format which may save us some trouble