### PR TITLE
try to catch SEGV inside with_subtest to provide a better diagnostic.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Test::Alien directive with_subtest will attempt to catch SEGV and bail
+    on on test file with a helpful diagnostic.  The prove util frequently
+    does not provide a useful diagnostic for SEGV on its own (gh#138, gh#139).
 
 1.86      2019-09-13 06:27:21 -0600
   - PAUSE permission fix

--- a/lib/Test/Alien.pm
+++ b/lib/Test/Alien.pm
@@ -687,6 +687,15 @@ sub xs_ok
 sub with_subtest (&)
 {
   my($code) = @_;
+
+  # it may be possible to catch a segmentation fault,
+  # but not with signal handlers apparently.  See:
+  # https://feepingcreature.github.io/handling.html
+  return $code if $^O eq 'MSWin32';
+
+  # try to catch a segmentation fault and bail out
+  # with a useful diagnostic.  prove test to swallow
+  # the diagnostic on such failures.
   sub {
     local $SIG{SEGV} = sub {
       my $ctx = context();

--- a/lib/Test/Alien.pm
+++ b/lib/Test/Alien.pm
@@ -684,7 +684,17 @@ sub xs_ok
   $ok;
 }
 
-sub with_subtest (&) { $_[0]; }
+sub with_subtest (&)
+{
+  my($code) = @_;
+  sub {
+    local $SIG{SEGV} = sub {
+      my $ctx = context();
+      $ctx->bail("Segmentation fault");
+    };
+    $code->(@_);
+  }
+}
 
 =head2 ffi_ok
 

--- a/t/test_alien.t
+++ b/t/test_alien.t
@@ -667,7 +667,7 @@ EOF
 
 subtest 'with_subtest SEGV' => sub {
 
-  skip_all => 'Test requires platforms with SEGV signal' if any { $_ eq 'SEGV' } split /\s+/, $Config{sig_name};
+  skip_all 'Test requires platforms with SEGV signal' if ! any { $_ eq 'SEGV' } split /\s+/, $Config{sig_name};
 
   our $kill_line;
 

--- a/t/test_alien.t
+++ b/t/test_alien.t
@@ -667,6 +667,11 @@ EOF
 
 subtest 'with_subtest SEGV' => sub {
 
+  # it may be possible to catch a segmentation fault,
+  # but not with signal handlers apparently.  See:
+  # https://feepingcreature.github.io/handling.html
+  skip_all 'Catching SEGV not currently supported on Windows' if $^O eq 'MSWin32';
+
   skip_all 'Test requires platforms with SEGV signal' if ! any { $_ eq 'SEGV' } split /\s+/, $Config{sig_name};
 
   our $kill_line;

--- a/t/test_alien.t
+++ b/t/test_alien.t
@@ -7,6 +7,7 @@ use Alien::libfoo1;
 use Env qw( @PATH );
 use ExtUtils::CBuilder;
 use Alien::Build::Util qw( _dump );
+use List::Util 1.33 qw( any );
 use Config;
 
 sub _reset
@@ -666,7 +667,7 @@ EOF
 
 subtest 'with_subtest SEGV' => sub {
 
-  skip_all => 'Test requires platforms with SEGV signal' if grep { $_ eq 'SEGV' } split /\s+/, $Config{sig_name};  
+  skip_all => 'Test requires platforms with SEGV signal' if any { $_ eq 'SEGV' } split /\s+/, $Config{sig_name};
 
   our $kill_line;
 


### PR DESCRIPTION
WIP implementation that requires testing for #138 