### PR TITLE
use the system / bsdtar on windows if avail

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Prefer tar.exe on Windows if it is bsdtar (gh#150)
 
 1.93      2019-12-09 02:22:44 -0700
   - curl plugin not used unless required -J option is supported.

--- a/lib/Alien/Build/Plugin/Extract/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Extract/CommandLine.pm
@@ -84,7 +84,7 @@ The C<tar> command, if available.  C<undef> if not available.
   sub _windows_tar_is_bsdtar
   {
     return 1 if $^O ne 'MSWin32';
-	return $bsd_tar if defined $bsd_tar;
+    return $bsd_tar if defined $bsd_tar;
     my($out) = capture_merged {
       system 'tar', '--version';
     };

--- a/lib/Alien/Build/Plugin/Extract/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Extract/CommandLine.pm
@@ -78,6 +78,20 @@ The C<tar> command, if available.  C<undef> if not available.
 
 =cut
 
+{
+  my $bsd_tar;
+
+  sub _windows_tar_is_bsdtar
+  {
+    return 1 if $^O ne 'MSWin32';
+	return $bsd_tar if defined $bsd_tar;
+    my($out) = capture_merged {
+      system 'tar', '--version';
+    };
+    return $bsd_tar = $out =~ /bsdtar/ ? 1 : 0
+  }
+}
+
 sub tar_cmd
 {
   _which('bsdtar')
@@ -91,7 +105,7 @@ sub tar_cmd
       # if we can, for now just assume that 'tar.exe' is borked
       # on windows to be on the safe side.  The Fetch::ArchiveTar
       # is probably a better plugin to use on windows anyway.
-      : _which('tar') && $^O ne 'MSWin32'
+      : _which('tar') && _windows_tar_is_bsdtar
         ? 'tar'
         : _which('ptar')
           ? 'ptar'

--- a/lib/Alien/Build/Plugin/Extract/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Extract/CommandLine.pm
@@ -81,6 +81,11 @@ The C<tar> command, if available.  C<undef> if not available.
 {
   my $bsd_tar;
 
+  # Note: GNU tar can be iffy to very bad on windows, where absolute
+  # paths get confused with remote tars.  We used to assume that 'tar.exe'
+  # is borked on Windows, but recent versions of Windows 10 come bundled
+  # with bsdtar (libarchive) named 'tar.exe', and we should definitely
+  # prefer that to ptar.
   sub _windows_tar_is_bsdtar
   {
     return 1 if $^O ne 'MSWin32';
@@ -100,11 +105,7 @@ sub tar_cmd
     # but seems to have gtar in the path by default, which is okay with it
     : $^O eq 'solaris' && _which('gtar')
       ? 'gtar'
-      # TODO: GNU tar can be iffy on windows, where absolute
-      # paths get confused with remote tars.  *sigh* fix later
-      # if we can, for now just assume that 'tar.exe' is borked
-      # on windows to be on the safe side.  The Fetch::ArchiveTar
-      # is probably a better plugin to use on windows anyway.
+      # See note above for Windows logic.
       : _which('tar') && _windows_tar_is_bsdtar
         ? 'tar'
         : _which('ptar')

--- a/lib/Alien/Build/Plugin/Extract/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Extract/CommandLine.pm
@@ -106,7 +106,7 @@ sub tar_cmd
     : $^O eq 'solaris' && _which('gtar')
       ? 'gtar'
       # See note above for Windows logic.
-      : _which('tar') && _windows_tar_is_bsdtar
+      : _which('tar') && _windows_tar_is_bsdtar()
         ? 'tar'
         : _which('ptar')
           ? 'ptar'


### PR DESCRIPTION
I learned recently that Windows 10 now comes with `bsdtar`!  Only it calls it `tar`.  We should prefer it over `ptar`.