### PR TITLE
remember which Mojo::DOM we are using

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Decode::Mojo plugin remembers which version of Mojo::DOM it is using (gh#159)
 
 1.98      2020-01-30 07:53:10 -0700
   - Production release identical to 1.97_01

--- a/lib/Alien/Build/Plugin/Decode/Mojo.pm
+++ b/lib/Alien/Build/Plugin/Decode/Mojo.pm
@@ -70,11 +70,13 @@ sub init
   $meta->add_requires('share' => 'URI' => 0);
   $meta->add_requires('share' => 'URI::Escape' => 0);
 
-  if($self->_class eq 'Mojo::DOM58')
+  my $class = $meta->prop->{plugin_decode_mojo_class} ||= $self->_class;
+
+  if($class eq 'Mojo::DOM58')
   {
     $meta->add_requires('share' => 'Mojo::DOM58' => '1.00');
   }
-  elsif($self->_class eq 'Mojo::DOM')
+  elsif($class eq 'Mojo::DOM')
   {
     $meta->add_requires('share' => 'Mojolicious' => '7.00');
     $meta->add_requires('share' => 'Mojo::DOM'   => '0');
@@ -90,7 +92,7 @@ sub init
     die "do not know how to decode @{[ $res->{type} ]}"
       unless $res->{type} eq 'html';
 
-    my $dom = $self->_class->new($res->{content});
+    my $dom = $class->new($res->{content});
 
     my $base = URI->new($res->{base});
 


### PR DESCRIPTION
This adds a little state to the `Decode::Mojo` plugin, and will hopefully help out with schizophrenic weridisms like this maybe:

```
Output from './Build':

Can't locate Mojo/DOM58.pm in @INC (you may need to install the Mojo::DOM58 module) (@INC contains: inc inc /opt/perl-5.31.8/lib/site_perl/5.31.8/x86_64-linux /opt/perl-5.31.8/lib/site_perl/5.31.8 /opt/perl-5.31.8/lib/5.31.8/x86_64-linux /opt/perl-5.31.8/lib/5.31.8 .) at /opt/perl-5.31.8/lib/site_perl/5.31.8/Alien/Build.pm line 306.
Building Acme-Alien-DontPanic2
Alien::Build::Plugin::PkgConfig::Negotiate> Using PkgConfig plugin: PkgConfig::CommandLine
```

