### PR TITLE
Sometimes prefer Decode::HTML plugin if HTML::Parser is already installed.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Prefer Decode::HTML if HTML::Parser is already installed and Mojolicious
+    or Mojo::DOM58 are not (gh#160)
 
 2.00      2020-02-02 06:25:13 -0700
   - Production release identical to 2.00

--- a/lib/Alien/Build/Plugin/Decode/Mojo.pm
+++ b/lib/Alien/Build/Plugin/Decode/Mojo.pm
@@ -59,7 +59,7 @@ sub _load ($;$)
 
 has _class => sub {
   return 'Mojo::DOM58' if _load 'Mojo::DOM58';
-  return 'Mojo::DOM'   if _load 'Mojo::DOM' && _load 'Mojolicious', 7.00;
+  return 'Mojo::DOM'   if _load 'Mojo::DOM' and _load 'Mojolicious', 7.00;
   return 'Mojo::DOM58';
 };
 

--- a/t/alien_build_plugin_download_negotiate.t
+++ b/t/alien_build_plugin_download_negotiate.t
@@ -8,6 +8,12 @@ use Alien::Build::Util qw( _dump );
 
 delete $ENV{$_} for qw( ftp_proxy all_proxy );
 
+my $mock_pick_decoder = mock 'Alien::Build::Plugin::Download::Negotiate' => (
+  override => [
+    _pick_decoder => sub { 'Decode::Mojo' },
+  ],
+);
+
 subtest 'pick fetch' => sub {
 
   local %ENV = %ENV;


### PR DESCRIPTION
We switched to using `Mojo::DOM` or `Mojo::DOM58` for decode since those are pure perl, and the older `Decode::HTML` had a dependency on `HTML::Parser` which is XS.  Unfortunately if AB gets upgraded between the config and build steps that can confuse the download and decode negotiation and it can require `HTML::Parser` in the config step and `Mojo::DOM*` in the build step when it is too late to change the prereqs and you will get an error trying to load `Mojo::DOM*`.  Ideally you don't change the AB between config and build, but it can happen sometimes.

To solve this we will use the older `HTML::Parser` plugin if `HTML::Parser` is already installed.  This is a good thing to do anyway, because it saves the prereq for `Mojo::DOM*` since AB has the capability to use `HTML::Parser` if available.

This PR also fixes a precedence bug that was in the `Decode::Mojo` plugin.