### PR TITLE
use strict & warnings in generated code in ::Install::Files

### DIFF
--- a/lib/Alien/Build/MM.pm
+++ b/lib/Alien/Build/MM.pm
@@ -514,6 +514,8 @@ sub import
           $install_files_pm->parent->mkpath;
           $install_files_pm->spew(
             "package ${mod}::Install::Files;\n",
+            "use strict;\n",
+            "use warnings;\n",
             "require ${mod};\n",
             "sub Inline { shift; ${mod}->Inline(\@_) }\n",
             "1;\n",


### PR DESCRIPTION
This adds

```
use strict;
use warnings;
```

To the generate `::Instal::Files` module