### PR TITLE
set version property on probe hook

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Fixed bug where Probe::Vcpkg plugin doesn't set version probe hook
+    property (gh#178)
 
 2.11      2020-03-09 03:04:49 -0600
   - Production release identical to 2.10

--- a/lib/Alien/Build/Plugin/Probe/Vcpkg.pm
+++ b/lib/Alien/Build/Plugin/Probe/Vcpkg.pm
@@ -134,6 +134,7 @@ sub init
           cflags  => $package->cflags,
           libs    => $package->libs,
         };
+        $build->hook_prop->{version} = $version;
         return 'system';
       },
     );


### PR DESCRIPTION
The version probe hook property was missing from the original implementation of the `Probe::Vcpkg` plugin.