### PR TITLE
Minor fix to Prefer::SortVersions plugin

### DIFF
--- a/lib/Alien/Build/Plugin/Prefer/SortVersions.pm
+++ b/lib/Alien/Build/Plugin/Prefer/SortVersions.pm
@@ -64,7 +64,7 @@ sub init
     my(undef, $res) = @_;
 
     my $cmp = sub {
-      my($A,$B) = map { $_ =~ $self->version } @_;
+      my($A,$B) = map { ($_ =~ $self->version)[0] } @_;
       Sort::Versions::versioncmp($B,$A);
     };
 


### PR DESCRIPTION
This PR protects against `version` regular expressions that have multiple capture groups - as is done on line 73.

https://github.com/Perl5-Alien/Alien-Build/blob/3771402e802fdb866909e38ebc6e69a9297b6264/lib/Alien/Build/Plugin/Prefer/SortVersions.pm#L73