### PR TITLE
Add dynamic_bin_dir method

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -761,30 +761,28 @@ sub bin_dir {
 }
 
 
-=head2 dynamic_bin_dir
+=head2 dynamic_dir
 
- my(@dir) = Alien::MyLibrary->dynamic_bin_dir
+ my(@dir) = Alien::MyLibrary->dynamic_dir
 
-Same as bin_dir, except that it returns the bin dir for a dynamic build
-(if the main build is static).  For a C<share> install this will be a
-directory under C<dist_dir> named C<dynamic> if it exists.  
+Returns the dynamic dir for a dynamic build (if the main
+build is static).  For a C<share> install this will be a
+directory under C<dist_dir> named C<dynamic> if it exists.
+System builds return an empty list.
 
 Example usage:
 
  use Env qw( @PATH );
  
- unshift @PATH, Alien::MyLibrary->dynamic_bin_dir;
+ unshift @PATH, Alien::MyLibrary->dynamic_dir;
 
 =cut
 
-sub dynamic_bin_dir {
+sub dynamic_dir {
   my ($class) = @_;
   if($class->install_type('system'))
   {
-    my $prop = $class->runtime_prop;
-    return () unless defined $prop;
-    return () unless defined $prop->{system_bin_dir};
-    return ref $prop->{system_bin_dir} ? @{ $prop->{system_bin_dir} } : ($prop->{system_bin_dir});
+    return ();
   }
   else
   {

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -740,7 +740,7 @@ Example usage:
 
  use Env qw( @PATH );
  
- unshft @PATH, Alien::MyLibrary->bin_dir;
+ unshift @PATH, Alien::MyLibrary->bin_dir;
 
 =cut
 
@@ -756,6 +756,39 @@ sub bin_dir {
   else
   {
     my $dir = Path::Tiny->new($class->dist_dir, 'bin');
+    return -d $dir ? ("$dir") : ();
+  }
+}
+
+
+=head2 dynamic_bin_dir
+
+ my(@dir) = Alien::MyLibrary->dynamic_bin_dir
+
+Same as bin_dir, except that it returns the bin dir for a dynamic build
+(if the main build is static).  For a C<share> install this will be a
+directory under C<dist_dir> named C<dynamic> if it exists.  
+
+Example usage:
+
+ use Env qw( @PATH );
+ 
+ unshift @PATH, Alien::MyLibrary->dynamic_bin_dir;
+
+=cut
+
+sub dynamic_bin_dir {
+  my ($class) = @_;
+  if($class->install_type('system'))
+  {
+    my $prop = $class->runtime_prop;
+    return () unless defined $prop;
+    return () unless defined $prop->{system_bin_dir};
+    return ref $prop->{system_bin_dir} ? @{ $prop->{system_bin_dir} } : ($prop->{system_bin_dir});
+  }
+  else
+  {
+    my $dir = Path::Tiny->new($class->dist_dir, 'dynamic');
     return -d $dir ? ("$dir") : ();
   }
 }

--- a/t/alien_base.t
+++ b/t/alien_base.t
@@ -120,6 +120,8 @@ subtest 'Alien::Build system' => sub {
 
   is( [Alien::libfoo1->dynamic_libs], ['/usr/lib/libfoo.so','/usr/lib/libfoo.so.1'], 'dynamic_libs' );
 
+  is( [Alien::libfoo1->dynamic_dir], [], 'dynamic_dir' );
+
   is( [Alien::libfoo1->bin_dir], [], 'bin_dir' );
 
   is( Alien::libfoo1->runtime_prop->{arbitrary}, 'one', 'runtime_prop' );
@@ -272,6 +274,15 @@ subtest 'Alien::Build share' => sub {
       end;
     },
     'bin_dir',
+  );
+
+  is(
+    [Alien::libfoo2->dynamic_dir],
+    array {
+      item match qr /\bdynamic$/;
+      end;
+    },
+    'dynamic_dir',
   );
 
   is( -f path(Alien::libfoo2->bin_dir)->child('foo-config'), T(), 'has a foo-config');


### PR DESCRIPTION
[WIP]

As discussed in https://github.com/Perl5-Alien/Alien-curl/issues/10#issuecomment-596263491 

Still to do:
- [x] It needs tests, but I'm not entirely sure where they should go.  
- [x] The system case is identical to that for bin_dir.  Should it be? Or is this likely to cause problems when system libs are statically compiled?  (Although there is no control at this level over system libs being static or dynamic).  
