### PR TITLE
Autoconf: Wrap pure perl pkg-config in shell script

### DIFF
--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -243,17 +243,17 @@ sub _pkgconf_wrapper {
 
   return if !_win;
 
-  my @found = File::Which::which $ENV{PKG_CONFIG}
-           || File::Which::which 'ppkg-config'
-           || File::Which::which 'pkg-config.pl'
-           || File::Which::which 'pkg-config';
+  my $found = (File::Which::which $ENV{PKG_CONFIG}
+            || File::Which::which 'ppkg-config'
+            || File::Which::which 'pkg-config.pl'
+            || File::Which::which 'pkg-config');
 
-  if (!@found) {
-    warn "Could not locate ppkg-config or pkg-config in your path:\n";
+  my $pk = $found;
+  if (!defined $pk) {
+    #warn "Could not locate ppkg-config or pkg-config in your path:\n";
     return;
   }
   
-  my $pk = $found[0];
   
   if ($pk =~ /\.bat$/i) {
     $pk =~ s/\.bat$//i;

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -245,7 +245,6 @@ sub _pkgconf_wrapper {
 
   my $pk = File::Which::which ($ENV{PKG_CONFIG})
         || File::Which::which ('ppkg-config')
-        || File::Which::which ('pkg-config.pl')
         || File::Which::which ('pkg-config');
 
   if (!defined $pk) {

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -243,14 +243,13 @@ sub _pkgconf_wrapper {
 
   return if !_win;
 
-  my $found = (File::Which::which $ENV{PKG_CONFIG}
-            || File::Which::which 'ppkg-config'
-            || File::Which::which 'pkg-config.pl'
-            || File::Which::which 'pkg-config');
+  my $pk = File::Which::which ($ENV{PKG_CONFIG})
+        || File::Which::which ('ppkg-config')
+        || File::Which::which ('pkg-config.pl')
+        || File::Which::which ('pkg-config');
 
-  my $pk = $found;
   if (!defined $pk) {
-    #warn "Could not locate ppkg-config or pkg-config in your path:\n";
+    $build->log ("Could not locate ppkg-config or pkg-config in your path:\n");
     return;
   }
   

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -287,7 +287,7 @@ EOWRAPPER
   ;
     $build->log ("Pure perl pkg-config detected on windows.\n");
     $build->log ("Wrapping $pk in shell script to cope with MSYS perl and paths.\n");
-    $fname = Path::Tiny->new($build->root, 'pkg-config');
+    $fname = Path::Tiny->new(File::Temp::tempdir( CLEANUP => 1 ))->child('pkg-config');
     open my $fh, '>', $fname
       or die "Unable to open pkg-config wrapper $fname, $!";
     print {$fh} $wrapper;

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -178,7 +178,7 @@ sub init
           $configure;
         }
       );
-      
+
       my $pkg_conf_wrapper = $self->_pkgconf_wrapper($build);
       local $ENV{PKG_CONFIG} = $pkg_conf_wrapper
         if $pkg_conf_wrapper;
@@ -241,7 +241,7 @@ Some reasonable default flags will be provided.
 sub _pkgconf_wrapper {
   my ($self, $build) = @_;
 
-  return if !_win;
+  return() if !_win;
 
   my $pk = File::Which::which ($ENV{PKG_CONFIG})
         || File::Which::which ('ppkg-config')
@@ -249,13 +249,13 @@ sub _pkgconf_wrapper {
 
   if (!defined $pk) {
     $build->log ("Could not locate ppkg-config or pkg-config in your path:\n");
-    return;
+    return();
   }
 
   $pk =~ s/\.bat$//i;
   if (!(-e $pk && -e "$pk.bat")) {
     $build->log ("$pk unlikely to be pure perl");
-    return;
+    return();
   }
 
   my $perl = $^X;
@@ -266,7 +266,7 @@ sub _pkgconf_wrapper {
     $path =~ s{\s}{\\ }g;
   }
   my $args = '$' . join ' $', (1..9);
-    
+
   my $wrapper = <<"EOWRAPPER"
 #/bin/sh
 
@@ -281,7 +281,7 @@ EOWRAPPER
   print {$fh} $wrapper;
   close ($fh);
   $build->log ("Setting \$ENV{PKG_CONFIG} to point to $fname\n");
-  
+
   return $fname;
 }
 

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -275,6 +275,7 @@ EOSTRING
     foreach my $path ($perl, $pk) {
       $path =~ s{\\}{/}g;
       $path =~ s{^([a-z]):/}{/$1/}i;
+      $path =~ s{\s}{\\ }g;
     }
     my $args = '$' . join ' $', (1..9);
     

--- a/lib/Alien/Build/Plugin/PkgConfig/PP.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/PP.pm
@@ -112,11 +112,9 @@ sub init
     my $command_line =
       File::Which::which('ppkg-config')
       ? 'ppkg-config'
-      : File::Which::which('pkg-config.pl')
-        ? 'pkg-config.pl'
-        : File::Which::which('pkg-config')
-          ? 'pkg-config'
-          : undef;
+      : File::Which::which('pkg-config')
+        ? 'pkg-config'
+        : undef;
     $meta->prop->{env}->{PKG_CONFIG} = $command_line
       if defined $command_line;
   }


### PR DESCRIPTION
This ensures it is called with the user's perl, not the MSYS perl, and properly handles windows paths in PKG_CONFIG_PATH.

To do:
- [ ] Tests
- [ ] Detect if msys plugin is being used, in which case it should be a no-op
- [x] log instead of warn when no pkg-config is found?

Supersedes #192 