### PR TITLE
Makefile: add targets to disable parallel installs

### DIFF
--- a/lib/Alien/Build/MM.pm
+++ b/lib/Alien/Build/MM.pm
@@ -422,7 +422,11 @@ sub mm_install
     $mm->SUPER::install(@rest);
   };
 
-  "install :: alien_clean_install\n\n$section";
+  return
+      ".NOTPARALLEL : install\n\n"
+    . ".NO_PARALLEL : install\n\n"
+    . "install :: alien_clean_install\n\n"
+    . $section;
 }
 
 sub import

--- a/lib/Alien/Build/MM.pm
+++ b/lib/Alien/Build/MM.pm
@@ -423,8 +423,8 @@ sub mm_install
   };
 
   return
-      ".NOTPARALLEL : install\n\n"
-    . ".NO_PARALLEL : install\n\n"
+      ".NOTPARALLEL : \n\n"
+    . ".NO_PARALLEL : \n\n"
     . "install :: alien_clean_install\n\n"
     . $section;
 }


### PR DESCRIPTION
I'm still not 100% confident about makefile syntax, but this at least runs without complaint on my own machine and on CI.  I don't think any of the tests check installation, though, and clean_install is certainly not tested.

The postamble sections look to be unaffected by parallelisation, as each of those targets has only singular dependencies.

The big block of concatenated strings might also be better as a heredoc.  

updates #197 
